### PR TITLE
Ongdb - 3.5 txDataUidUpdates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ idea {
 }
 
 group = 'org.neo4j.procedure'
-version = '3.5.0.5'
+version = '3.5.0.6'
 archivesBaseName = 'apoc'
 
 jar {
@@ -272,7 +272,7 @@ asciidoctor {
     sources { include 'index.adoc' }
     outputDir = file('build/docs')
     attributes  'apoc-version' : version,
-                'apoc-release' : "3.5.0.5",
+                'apoc-release' : "3.5.0.6",
                 'neo4j-version' : neo4jVersionEffective,
                 'branch' : "3.5"
 }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -29,7 +29,7 @@ plugins {
     id 'org.neo4j.doc.build.docbook' version '1.0-alpha12'
 }
 
-if (!project.hasProperty('apocVersion')) { ext.apocVersion = '3.5.0.5' }
+if (!project.hasProperty('apocVersion')) { ext.apocVersion = '3.5.0.6' }
 
 ext {
     versionParts = apocVersion.split('-')

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.neo4j.procedure</groupId>
     <artifactId>apoc-docs</artifactId>
-    <version>3.5.0.2</version>
+    <version>3.5.0.6</version>
 
     <name>apoc-docs</name>
     <description>Awesome Procedures for Cypher - Documentation</description>

--- a/src/main/java/apoc/trigger/TransactionDataMap.java
+++ b/src/main/java/apoc/trigger/TransactionDataMap.java
@@ -3,7 +3,6 @@ package apoc.trigger;
 import apoc.util.JsonUtil;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -12,13 +11,16 @@ import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.graphdb.event.TransactionData;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class TransactionDataMap
@@ -57,9 +59,7 @@ public class TransactionDataMap
 
     }
 
-
-
-    public static Map<String,Map<String,Object>> updatedNodeMap( TransactionData tx, Iterable<Node> updatedNodes, String uidKey, ActionType actionType )
+    public static Map<String,Map<String,Object>> updatedNodeMap( TxDataWrapper txDataWrapper, Iterable<Node> updatedNodes, ActionType actionType )
     {
         Map<String,Map<String,Object>> nodeChanges = new HashMap<>();
 
@@ -67,36 +67,25 @@ public class TransactionDataMap
         while ( updatedNodesIterator.hasNext() )
         {
             Node node = updatedNodesIterator.next();
-            String nodeUid = Long.toString( node.getId() );
+            String uniqueIdentifier = txDataWrapper.getNodeUid( node.getId() );
 
-            switch ( actionType )
-            {
-            case ADDED:
-                nodeUid = (String) node.getProperty( uidKey, Long.toString( node.getId() ) );
-                break;
-            case REMOVED:
-                nodeUid = getNodeUidFromPreviousCommit( tx, uidKey, node.getId() );
-                break;
-            }
-
-            nodeChanges.put( nodeUid, toMap( new NodeChange( actionType ) ) );
+            nodeChanges.put( uniqueIdentifier, toMap( new NodeChange( actionType ) ) );
         }
 
         return nodeChanges.isEmpty() ? Collections.emptyMap() : nodeChanges;
     }
 
-    public static Map<String,Map<String,Object>> createdNodeMap( TransactionData tx, String uidKey )
+    public static Map<String,Map<String,Object>> createdNodeMap( TxDataWrapper txDataWrapper )
     {
-        return updatedNodeMap( tx, tx.createdNodes(), uidKey, ActionType.ADDED );
+        return updatedNodeMap( txDataWrapper, txDataWrapper.getTransactionData().createdNodes(), ActionType.ADDED );
     }
 
-    public static Map<String,Map<String,Object>> deletedNodeMap( TransactionData tx, String uidKey )
+    public static Map<String,Map<String,Object>> deletedNodeMap( TxDataWrapper txDataWrapper )
     {
-        return updatedNodeMap( tx, tx.deletedNodes(), uidKey, ActionType.REMOVED );
+        return updatedNodeMap( txDataWrapper, txDataWrapper.getTransactionData().deletedNodes(), ActionType.REMOVED );
     }
 
-    public static Map<String,Map<String,Object>> updatedRelationshipsMap( TransactionData tx, Iterable<Relationship> updatedRelationships, String uidKey,
-            ActionType actionType )
+    public static Map<String,Map<String,Object>> updatedRelationshipsMap( TxDataWrapper txDataWrapper, Iterable<Relationship> updatedRelationships, ActionType actionType )
     {
         Map<String,Map<String,Object>> relationshipChanges = new HashMap<>();
 
@@ -108,63 +97,28 @@ public class TransactionDataMap
             Node startNode = relationship.getStartNode();
             Node endNode = relationship.getEndNode();
 
-            String relationshipUid = Long.toString( relationship.getId() );
-            String startNodeUid = Long.toString( relationship.getId() );
-            String endNodeUid = Long.toString( relationship.getId() );
+            String relationshipUid = txDataWrapper.getRelationshipUid( relationship.getId() );
+            String startNodeUid = txDataWrapper.getNodeUid( startNode.getId() );
+            String endNodeUid = txDataWrapper.getNodeUid( endNode.getId() );
 
-            switch ( actionType )
-            {
-            case ADDED:
-                relationshipUid = (String) relationship.getProperty( uidKey, Long.toString( relationship.getId() ) );
-                break;
-            case REMOVED:
-                relationshipUid = getRelationshipUidFromPreviousCommit( tx, uidKey, relationship.getId() );
-                break;
-            }
-
-            // Check if the start node has been deleted
-            if ( StreamSupport.stream( tx.deletedNodes().spliterator(), false ).map( Node::getId ).collect( Collectors.toList() ).contains(
-                    startNode.getId() ) )
-            {
-                // Also if deleted get the old value of uidKey
-                startNodeUid = getNodeUidFromPreviousCommit( tx, uidKey, startNode.getId() );
-            }
-            else
-            {
-                // If not deleted set the entityUid based which property was removed
-                startNodeUid = (String) startNode.getProperty( uidKey, Long.toString( startNode.getId() ) );
-            }
-
-            // Check if the end node has been deleted
-            if ( StreamSupport.stream( tx.deletedNodes().spliterator(), false ).map( Node::getId ).collect( Collectors.toList() ).contains(
-                    endNode.getId() ) )
-            {
-                // Also if deleted get the old value of uidKey
-                endNodeUid = getNodeUidFromPreviousCommit( tx, uidKey, endNode.getId() );
-            }
-            else
-            {
-                // If not deleted set the entityUid based which property was removed
-                endNodeUid = (String) endNode.getProperty( uidKey, Long.toString( endNode.getId() ) );
-            }
-
-            relationshipChanges.put( relationshipUid, toMap( new RelationshipChange( startNodeUid, endNodeUid, relationship.getType().name(), actionType ) ) );
+            relationshipChanges.put( relationshipUid,
+                    toMap( new RelationshipChange( startNodeUid, endNodeUid, relationship.getType().name(), actionType ) ) );
         }
 
         return relationshipChanges.isEmpty() ? Collections.emptyMap() : relationshipChanges;
     }
 
-    public static Map<String,Map<String,Object>> createdRelationshipsMap( TransactionData tx, String uidKey )
+    public static Map<String,Map<String,Object>> createdRelationshipsMap( TxDataWrapper txDataWrapper )
     {
-        return updatedRelationshipsMap( tx, tx.createdRelationships(), uidKey, ActionType.ADDED );
+        return updatedRelationshipsMap( txDataWrapper, txDataWrapper.getTransactionData().createdRelationships(), ActionType.ADDED );
     }
 
-    public static Map<String,Map<String,Object>> deletedRelationshipsMap( TransactionData tx, String uidKey )
+    public static Map<String,Map<String,Object>> deletedRelationshipsMap( TxDataWrapper txDataWrapper )
     {
-        return updatedRelationshipsMap( tx, tx.deletedRelationships(), uidKey, ActionType.REMOVED );
+        return updatedRelationshipsMap( txDataWrapper, txDataWrapper.getTransactionData().deletedRelationships(), ActionType.REMOVED );
     }
 
-    public static Map<String,List<Map<String,Object>>> updatedLabelMapByLabel( TransactionData tx, Iterable<LabelEntry> assignedLabels, String uidKey,
+    public static Map<String,List<Map<String,Object>>> updatedLabelMapByLabel( TxDataWrapper txDataWrapper, Iterable<LabelEntry> assignedLabels,
             ActionType actionType )
     {
         Map<String,List<Map<String,Object>>> labelChanges = new HashMap<>();
@@ -176,28 +130,7 @@ public class TransactionDataMap
             Node updatedNode = labelEntry.node();
 
             String label = labelEntry.label().name();
-            String nodeUid = Long.toString( updatedNode.getId() );
-
-            switch ( actionType )
-            {
-            case ADDED:
-                nodeUid = (String) updatedNode.getProperty( uidKey, Long.toString( updatedNode.getId() ) );
-                break;
-            case REMOVED:
-                // Check if the start node has been deleted
-                if ( StreamSupport.stream( tx.deletedNodes().spliterator(), false ).map( Node::getId ).collect( Collectors.toList() ).contains(
-                        updatedNode.getId() ) )
-                {
-                    // Also if deleted get the old value of uidKey
-                    nodeUid = getNodeUidFromPreviousCommit( tx, uidKey, updatedNode.getId() );
-                }
-                else
-                {
-                    // If not deleted set the entityUid based which property was removed
-                    nodeUid = (String) updatedNode.getProperty( uidKey, Long.toString( updatedNode.getId() ) );
-                }
-                break;
-            }
+            String nodeUid = txDataWrapper.getNodeUid( updatedNode.getId() );
 
             if ( !labelChanges.containsKey( label ) )
             {
@@ -209,17 +142,17 @@ public class TransactionDataMap
         return labelChanges.isEmpty() ? Collections.emptyMap() : labelChanges;
     }
 
-    public static Map<String,List<Map<String,Object>>> assignedLabelMapByLabel( TransactionData tx, String uidKey )
+    public static Map<String,List<Map<String,Object>>> assignedLabelMapByLabel( TxDataWrapper txDataWrapper )
     {
-        return updatedLabelMapByLabel( tx, tx.assignedLabels(), uidKey, ActionType.ADDED );
+        return updatedLabelMapByLabel( txDataWrapper, txDataWrapper.getTransactionData().assignedLabels(), ActionType.ADDED );
     }
 
-    public static Map<String,List<Map<String,Object>>> removedLabelMapByLabel( TransactionData tx, String uidKey )
+    public static Map<String,List<Map<String,Object>>> removedLabelMapByLabel( TxDataWrapper txDataWrapper )
     {
-        return updatedLabelMapByLabel( tx, tx.removedLabels(), uidKey, ActionType.REMOVED );
+        return updatedLabelMapByLabel( txDataWrapper, txDataWrapper.getTransactionData().removedLabels(), ActionType.REMOVED );
     }
 
-    public static Map<String,List<String>> updatedLabelMapByUid( TransactionData tx, Iterable<LabelEntry> assignedLabels, String uidKey,
+    public static Map<String,List<String>> updatedLabelMapByUid( TxDataWrapper txDataWrapper, Iterable<LabelEntry> assignedLabels,
             ActionType actionType )
     {
         Map<String,List<String>> uidTolabelsMap = new HashMap<>();
@@ -231,28 +164,7 @@ public class TransactionDataMap
             Node updatedNode = labelEntry.node();
 
             String label = labelEntry.label().name();
-            String nodeUid = Long.toString( updatedNode.getId() );
-
-            switch ( actionType )
-            {
-            case ADDED:
-                nodeUid = (String) updatedNode.getProperty( uidKey, Long.toString( updatedNode.getId() ) );
-                break;
-            case REMOVED:
-                // Check if the start node has been deleted
-                if ( StreamSupport.stream( tx.deletedNodes().spliterator(), false ).map( Node::getId ).collect( Collectors.toList() ).contains(
-                        updatedNode.getId() ) )
-                {
-                    // Also if deleted get the old value of uidKey
-                    nodeUid = getNodeUidFromPreviousCommit( tx, uidKey, updatedNode.getId() );
-                }
-                else
-                {
-                    // If not deleted set the entityUid based which property was removed
-                    nodeUid = (String) updatedNode.getProperty( uidKey, Long.toString( updatedNode.getId() ) );
-                }
-                break;
-            }
+            String nodeUid = txDataWrapper.getNodeUid( updatedNode.getId() );
 
             if ( !uidTolabelsMap.containsKey( nodeUid ) )
             {
@@ -264,26 +176,21 @@ public class TransactionDataMap
         return uidTolabelsMap.isEmpty() ? Collections.emptyMap() : uidTolabelsMap;
     }
 
-    public static Map<String,List<String>> assignedLabelMapByUid( TransactionData tx, String uidKey )
+    public static Map<String,List<String>> assignedLabelMapByUid( TxDataWrapper txDataWrapper )
     {
-        return updatedLabelMapByUid( tx, tx.assignedLabels(), uidKey, ActionType.ADDED );
+        return updatedLabelMapByUid( txDataWrapper, txDataWrapper.getTransactionData().assignedLabels(), ActionType.ADDED );
     }
 
-    public static Map<String,List<String>> removedLabelMapByUid( TransactionData tx, String uidKey )
+    public static Map<String,List<String>> removedLabelMapByUid( TxDataWrapper txDataWrapper )
     {
-        return updatedLabelMapByUid( tx, tx.removedLabels(), uidKey, ActionType.REMOVED );
+        return updatedLabelMapByUid( txDataWrapper, txDataWrapper.getTransactionData().removedLabels(), ActionType.REMOVED );
     }
 
     /**
      * Returns the updated node properties by key (property name) and value (list of node uids).
-     * @param tx
-     * @param entityIterable
-     * @param uidKey
-     * @param actionType
-     * @return
      */
-    public static Map<String,List<String>> updatedNodePropertyMapByKey( TransactionData tx,
-            Iterable<PropertyEntry<Node>> entityIterable, String uidKey, ActionType actionType )
+    public static Map<String,List<String>> updatedNodePropertyMapByKey( TxDataWrapper txDataWrapper, Iterable<PropertyEntry<Node>> entityIterable,
+            ActionType actionType )
     {
         Map<String,List<String>> propertyChanges = new HashMap<>();
 
@@ -293,24 +200,9 @@ public class TransactionDataMap
             PropertyEntry<Node> entityPropertyEntry = entityIterator.next();
 
             String propertyKey = entityPropertyEntry.key();
-
             Node updatedEntity = entityPropertyEntry.entity();
 
-            String entityUid = Long.toString( updatedEntity.getId() );
-
-            // Check if the node has been deleted
-            if ( StreamSupport.stream( tx.deletedNodes().spliterator(), false ).map( n -> n.getId() ).collect( Collectors.toList() ).contains(
-                    updatedEntity.getId() ) )
-            {
-                // If deleted get the old value of uidKey
-                entityUid = getNodeUidFromPreviousCommit( tx, uidKey, updatedEntity.getId() );
-            }
-            else
-            {
-                // If not deleted set the entityUid based which property was removed
-                entityUid = (actionType.equals( ActionType.REMOVED ) && propertyKey.equals( uidKey ) ) ? getNodeUidFromPreviousCommit( tx, uidKey, updatedEntity.getId() )
-                                                                                                       : (String) updatedEntity.getProperty( uidKey, Long.toString( updatedEntity.getId() ) );
-            }
+            String entityUid = txDataWrapper.getNodeUid( updatedEntity.getId() );
 
             if (!propertyChanges.containsKey( propertyKey ))
             {
@@ -323,19 +215,19 @@ public class TransactionDataMap
         return propertyChanges.isEmpty() ? Collections.emptyMap() : propertyChanges;
     }
 
-    public static Map<String,List<String>> assignedNodePropertyMapByKey( TransactionData tx, String uidKey )
+    public static Map<String,List<String>> assignedNodePropertyMapByKey( TxDataWrapper txDataWrapper )
     {
-        return updatedNodePropertyMapByKey( tx, tx.assignedNodeProperties(), uidKey, ActionType.ADDED );
+        return updatedNodePropertyMapByKey( txDataWrapper, txDataWrapper.getTransactionData().assignedNodeProperties(), ActionType.ADDED );
     }
 
-    public static Map<String,List<String>> removedNodePropertyMapByKey( TransactionData tx, String uidKey )
+    public static Map<String,List<String>> removedNodePropertyMapByKey( TxDataWrapper txDataWrapper )
     {
-        return updatedNodePropertyMapByKey( tx, tx.removedNodeProperties(), uidKey, ActionType.REMOVED );
+        return updatedNodePropertyMapByKey( txDataWrapper, txDataWrapper.getTransactionData().removedNodeProperties(), ActionType.REMOVED );
     }
 
 
-    public static Map<String,Map<String,List<Map<String,Object>>>> updatedNodePropertyMapByLabel( TransactionData tx,
-            Iterable<PropertyEntry<Node>> entityIterable, String uidKey, ActionType actionType, Function<Long,String> uidFunction )
+    public static Map<String,Map<String,List<Map<String,Object>>>> updatedNodePropertyMapByLabel( TxDataWrapper txDataWrapper,
+            Iterable<PropertyEntry<Node>> entityIterable, ActionType actionType )
     {
         Map<String,Map<String,List<Map<String,Object>>>> propertyChanges = new HashMap<>();
 
@@ -347,41 +239,36 @@ public class TransactionDataMap
             String propertyKey = entityPropertyEntry.key();
             Node updatedEntity = entityPropertyEntry.entity();
 
-            String entityUid = Long.toString( updatedEntity.getId() );
+            String entityUid = txDataWrapper.getNodeUid( updatedEntity.getId() );
 
             List<String> labels = new ArrayList<>();
 
             if ( actionType.equals( ActionType.REMOVED ) )
             {
                 // Get the nodes where the node properties were removed
-                Node node = ((Function<Long,Node>) ( Long id ) -> StreamSupport.stream( tx.removedNodeProperties().spliterator(), true ).filter(
+                Node node = ((Function<Long,Node>) ( Long id ) -> StreamSupport.stream( txDataWrapper.getTransactionData().removedNodeProperties().spliterator(), true ).filter(
                         nodePropertyEntry -> id.equals( nodePropertyEntry.entity().getId() ) ).reduce( ( t1, t2 ) -> t1 ).get().entity()).apply(
                         updatedEntity.getId() );
 
                 // Check if the node has been deleted
-                if ( StreamSupport.stream( tx.deletedNodes().spliterator(), false ).map( n -> n.getId() ).collect( Collectors.toList() ).contains(
+                if ( StreamSupport.stream( txDataWrapper.getTransactionData().deletedNodes().spliterator(), false ).map( n -> n.getId() ).collect( Collectors.toList() ).contains(
                         node.getId() ) )
                 {
                     // If deleted get the labels from the transaction data.
-                    labels.addAll( StreamSupport.stream( tx.removedLabels().spliterator(), false ).filter(
+                    labels.addAll( StreamSupport.stream( txDataWrapper.getTransactionData().removedLabels().spliterator(), false ).filter(
                             labelEntry -> labelEntry.node().getId() == node.getId() ).map( labelEntry -> labelEntry.label().name() ).collect(
                             Collectors.toList() ) );
 
-                    // Also if deleted get the old value of uidKey
-                    entityUid = uidFunction.apply( updatedEntity.getId() );
                 }
                 else
                 {
                     labels.addAll( StreamSupport.stream( node.getLabels().spliterator(), true ).map( label -> label.name() ).collect( Collectors.toList() ) );
 
-                    // If not deleted set the entityUid based which property was removed
-                    entityUid = propertyKey.equals( uidKey ) ? uidFunction.apply( updatedEntity.getId() ) : (String) updatedEntity.getProperty( uidKey, Long.toString( updatedEntity.getId() ) );
                 }
             }
             else
             {
                 labels = StreamSupport.stream( updatedEntity.getLabels().spliterator(), true ).map( Label::name ).collect( Collectors.toList() );
-                entityUid = (String) updatedEntity.getProperty( uidKey, Long.toString( updatedEntity.getId() ) );
             }
 
             for ( String label : labels )
@@ -411,20 +298,17 @@ public class TransactionDataMap
         return propertyChanges.isEmpty() ? Collections.emptyMap() : propertyChanges;
     }
 
-    public static Map<String,Map<String,List<Map<String,Object>>>> assignedNodePropertyMapByLabel( TransactionData tx, String uidKey )
+    public static Map<String,Map<String,List<Map<String,Object>>>> assignedNodePropertyMapByLabel( TxDataWrapper txDataWrapper )
     {
-        return updatedNodePropertyMapByLabel( tx, tx.assignedNodeProperties(), uidKey, ActionType.ADDED,
-                ( l ) -> getNodeUidFromPreviousCommit( tx, uidKey, l ) );
+        return updatedNodePropertyMapByLabel( txDataWrapper, txDataWrapper.getTransactionData().assignedNodeProperties(), ActionType.ADDED );
     }
 
-    public static Map<String,Map<String,List<Map<String,Object>>>> removedNodePropertyMapByLabel( TransactionData tx, String uidKey )
+    public static Map<String,Map<String,List<Map<String,Object>>>> removedNodePropertyMapByLabel( TxDataWrapper txDataWrapper )
     {
-        return updatedNodePropertyMapByLabel( tx, tx.removedNodeProperties(), uidKey, ActionType.REMOVED,
-                ( l ) -> getNodeUidFromPreviousCommit( tx, uidKey, l ) );
+        return updatedNodePropertyMapByLabel( txDataWrapper, txDataWrapper.getTransactionData().removedNodeProperties(), ActionType.REMOVED );
     }
 
-    public static Map<String,List<Map<String,Object>>> updatedNodePropertyMapByUid( TransactionData tx,
-            Iterable<PropertyEntry<Node>> entityIterable, String uidKey, ActionType actionType, Function<Long,String> uidFunction )
+    public static Map<String,List<Map<String,Object>>> updatedNodePropertyMapByUid( TxDataWrapper txDataWrapper, Iterable<PropertyEntry<Node>> entityIterable, ActionType actionType )
     {
         Map<String,List<Map<String,Object>>> propertyChanges = new HashMap<>();
 
@@ -436,21 +320,7 @@ public class TransactionDataMap
             String propertyKey = entityPropertyEntry.key();
             Node updatedEntity = entityPropertyEntry.entity();
 
-            String entityUid = Long.toString( updatedEntity.getId() );
-
-            // Check if the node has been deleted
-            if ( StreamSupport.stream( tx.deletedNodes().spliterator(), false ).map( n -> n.getId() ).collect( Collectors.toList() ).contains(
-                    updatedEntity.getId() ) )
-            {
-                // If deleted get the old value of uidKey
-                entityUid = uidFunction.apply( updatedEntity.getId() );
-            }
-            else
-            {
-                // If not deleted set the entityUid based which property was removed
-                entityUid = (actionType.equals( ActionType.REMOVED ) && propertyKey.equals( uidKey ) ) ? uidFunction.apply( updatedEntity.getId() )
-                                                                                                       : (String) updatedEntity.getProperty( uidKey, Long.toString( updatedEntity.getId() ) );
-            }
+            String entityUid = txDataWrapper.getNodeUid( updatedEntity.getId() );
 
             if ( !propertyChanges.containsKey( entityUid ) )
             {
@@ -471,8 +341,19 @@ public class TransactionDataMap
 
         return propertyChanges.isEmpty() ? Collections.emptyMap() : propertyChanges;
     }
-    public static Map<String,List<Map<String,Object>>> updatedRelationshipPropertyMapByUid( TransactionData tx,
-            Iterable<PropertyEntry<Relationship>> entityIterable, String uidKey, ActionType actionType, Function<Long,String> uidFunction )
+
+    public static Map<String,List<Map<String,Object>>> assignedNodePropertyMapByUid( TxDataWrapper txDataWrapper )
+    {
+        return updatedNodePropertyMapByUid( txDataWrapper, txDataWrapper.getTransactionData().assignedNodeProperties(), ActionType.ADDED );
+    }
+
+    public static Map<String,List<Map<String,Object>>> removedNodePropertyMapByUid( TxDataWrapper txDataWrapper )
+    {
+        return updatedNodePropertyMapByUid( txDataWrapper, txDataWrapper.getTransactionData().removedNodeProperties(), ActionType.REMOVED );
+    }
+
+    public static Map<String,List<Map<String,Object>>> updatedRelationshipPropertyMapByUid( TxDataWrapper txDataWrapper,
+            Iterable<PropertyEntry<Relationship>> entityIterable, ActionType actionType )
     {
         Map<String,List<Map<String,Object>>> propertyChanges = new HashMap<>();
 
@@ -484,23 +365,7 @@ public class TransactionDataMap
             String propertyKey = entityPropertyEntry.key();
             Relationship updatedEntity = entityPropertyEntry.entity();
 
-
-
-            String entityUid = Long.toString( updatedEntity.getId() );
-
-            // Check if the relationship has been deleted
-            if ( StreamSupport.stream( tx.deletedRelationships().spliterator(), false ).map( n -> n.getId() ).collect( Collectors.toList() ).contains(
-                    updatedEntity.getId() ) )
-            {
-                // If deleted get the old value of uidKey
-                entityUid = uidFunction.apply( updatedEntity.getId() );
-            }
-            else
-            {
-                // If not deleted set the entityUid based which property was removed
-                entityUid = (actionType.equals( ActionType.REMOVED ) && propertyKey.equals( uidKey ) ) ? uidFunction.apply( updatedEntity.getId() )
-                                                                                                       : (String) updatedEntity.getProperty( uidKey, Long.toString( updatedEntity.getId() ) );
-            }
+            String entityUid = txDataWrapper.getRelationshipUid( updatedEntity.getId() );
 
             if ( !propertyChanges.containsKey( entityUid ) )
             {
@@ -514,39 +379,25 @@ public class TransactionDataMap
             else
             {
                 propertyChanges.get( entityUid ).add(
-                        toMap( new PropertyChange( propertyKey, entityPropertyEntry.value(), entityPropertyEntry.previouslyCommitedValue(),
-                                actionType ) ) );
+                        toMap( new PropertyChange( propertyKey, entityPropertyEntry.value(), entityPropertyEntry.previouslyCommitedValue(), actionType ) ) );
             }
         }
 
         return propertyChanges.isEmpty() ? Collections.emptyMap() : propertyChanges;
     }
 
-
-    public static Map<String,List<Map<String,Object>>> assignedNodePropertyMapByUid( TransactionData tx, String uidKey )
+    public static Map<String,List<Map<String,Object>>> assignedRelationshipPropertyMapByUid( TxDataWrapper txDataWrapper )
     {
-        return updatedNodePropertyMapByUid( tx, tx.assignedNodeProperties(), uidKey, ActionType.ADDED, ( l ) -> getNodeUidFromPreviousCommit( tx, uidKey, l ) );
+        return updatedRelationshipPropertyMapByUid( txDataWrapper, txDataWrapper.getTransactionData().assignedRelationshipProperties(), ActionType.ADDED );
     }
 
-    public static Map<String,List<Map<String,Object>>> assignedRelationshipPropertyMapByUid( TransactionData tx, String uidKey )
+    public static Map<String,List<Map<String,Object>>> removedRelationshipPropertyMapByUid( TxDataWrapper txDataWrapper )
     {
-        return updatedRelationshipPropertyMapByUid( tx, tx.assignedRelationshipProperties(), uidKey, ActionType.ADDED,
-                ( l ) -> getRelationshipUidFromPreviousCommit( tx, uidKey, l ) );
+        return updatedRelationshipPropertyMapByUid( txDataWrapper, txDataWrapper.getTransactionData().removedRelationshipProperties(), ActionType.REMOVED );
     }
 
-    public static Map<String,List<Map<String,Object>>> removedNodePropertyMapByUid( TransactionData tx, String uidKey )
-    {
-        return updatedNodePropertyMapByUid( tx, tx.removedNodeProperties(), uidKey, ActionType.REMOVED, ( l ) -> getNodeUidFromPreviousCommit( tx, uidKey, l ) );
-    }
-
-    public static Map<String,List<Map<String,Object>>> removedRelationshipPropertyMapByUid( TransactionData tx, String uidKey )
-    {
-        return updatedRelationshipPropertyMapByUid( tx, tx.removedRelationshipProperties(), uidKey, ActionType.REMOVED,
-                ( l ) -> getRelationshipUidFromPreviousCommit( tx, uidKey, l ) );
-    }
-
-    public static Map<String,List<String>> updatedRelationshipPropertyMapByKey( TransactionData tx,
-            Iterable<PropertyEntry<Relationship>> entityIterable, String uidKey, ActionType actionType, Function<Long,String> uidFunction )
+    public static Map<String,List<String>> updatedRelationshipPropertyMapByKey( TxDataWrapper txDataWrapper,
+            Iterable<PropertyEntry<Relationship>> entityIterable, ActionType actionType )
     {
         Map<String,List<String>> propertyChanges = new HashMap<>();
 
@@ -558,21 +409,7 @@ public class TransactionDataMap
             String propertyKey = entityPropertyEntry.key();
             Relationship updatedEntity = entityPropertyEntry.entity();
 
-            String entityUid = Long.toString( updatedEntity.getId() );
-
-            // Check if the relationship has been deleted
-            if ( StreamSupport.stream( tx.deletedRelationships().spliterator(), false ).map( n -> n.getId() ).collect( Collectors.toList() ).contains(
-                    updatedEntity.getId() ) )
-            {
-                // If deleted get the old value of uidKey
-                entityUid = getRelationshipUidFromPreviousCommit( tx, uidKey, updatedEntity.getId() );
-            }
-            else
-            {
-                // If not deleted set the entityUid based which property was removed
-                entityUid = (actionType.equals( ActionType.REMOVED ) && propertyKey.equals( uidKey ) ) ? getRelationshipUidFromPreviousCommit( tx, uidKey, updatedEntity.getId() )
-                                                                                                       : (String) updatedEntity.getProperty( uidKey, Long.toString( updatedEntity.getId() ) );
-            }
+            String entityUid = txDataWrapper.getRelationshipUid( updatedEntity.getId() );
 
             if ( !propertyChanges.containsKey( propertyKey ) )
             {
@@ -586,20 +423,18 @@ public class TransactionDataMap
         return propertyChanges.isEmpty() ? Collections.emptyMap() : propertyChanges;
     }
 
-    public static Map<String,List<String>> assignedRelationshipPropertyMapByKey( TransactionData tx, String uidKey )
+    public static Map<String,List<String>> assignedRelationshipPropertyMapByKey( TxDataWrapper txDataWrapper )
     {
-        return updatedRelationshipPropertyMapByKey( tx, tx.assignedRelationshipProperties(), uidKey, ActionType.ADDED,
-                ( l ) -> getRelationshipUidFromPreviousCommit( tx, uidKey, l ) );
+        return updatedRelationshipPropertyMapByKey( txDataWrapper, txDataWrapper.getTransactionData().assignedRelationshipProperties(), ActionType.ADDED );
     }
 
-    public static Map<String,List<String>> removedRelationshipPropertyMapByKey( TransactionData tx, String uidKey )
+    public static Map<String,List<String>> removedRelationshipPropertyMapByKey( TxDataWrapper txDataWrapper )
     {
-        return updatedRelationshipPropertyMapByKey( tx, tx.removedRelationshipProperties(), uidKey, ActionType.REMOVED,
-                ( l ) -> getRelationshipUidFromPreviousCommit( tx, uidKey, l ) );
+        return updatedRelationshipPropertyMapByKey( txDataWrapper, txDataWrapper.getTransactionData().removedRelationshipProperties(), ActionType.REMOVED );
     }
 
-    public static Map<String,Map<String,List<Map<String,Object>>>> updatedRelationshipPropertyMapByType( TransactionData tx,
-            Iterable<PropertyEntry<Relationship>> entityIterable, String uidKey, ActionType actionType, Function<Long,String> uidFunction )
+    public static Map<String,Map<String,List<Map<String,Object>>>> updatedRelationshipPropertyMapByType( TxDataWrapper txDataWrapper,
+            Iterable<PropertyEntry<Relationship>> entityIterable, ActionType actionType )
     {
         Map<String,Map<String,List<Map<String,Object>>>> propertyChanges = new HashMap<>();
 
@@ -611,42 +446,33 @@ public class TransactionDataMap
             String propertyKey = entityPropertyEntry.key();
             Relationship updatedEntity = entityPropertyEntry.entity();
 
-            // Check if the property was removed and if it was, check if the property removed was the same property as the uidKey.
-            String entityUid = Long.toString( updatedEntity.getId() );
+            String entityUid = txDataWrapper.getRelationshipUid( updatedEntity.getId() );
 
             List<String> types = new ArrayList<>();
 
             if ( actionType.equals( ActionType.REMOVED ) )
             {
                 // Get the nodes where the node properties were removed
-                Relationship relationship = ((Function<Long,Relationship>) ( Long id ) -> StreamSupport.stream( tx.removedRelationshipProperties().spliterator(), true ).filter(
+                Relationship relationship = ((Function<Long,Relationship>) ( Long id ) -> StreamSupport.stream( txDataWrapper.getTransactionData().removedRelationshipProperties().spliterator(), true ).filter(
                         relationshipPropertyEntry -> id.equals( relationshipPropertyEntry.entity().getId() ) ).reduce( ( t1, t2 ) -> t1 ).get().entity()).apply(
                         updatedEntity.getId() );
 
                 // Check if the relationship has been deleted
-                if ( StreamSupport.stream( tx.deletedRelationships().spliterator(), false ).map( Relationship::getId ).collect( Collectors.toList() ).contains(
+                if ( StreamSupport.stream( txDataWrapper.getTransactionData().deletedRelationships().spliterator(), false ).map( Relationship::getId ).collect( Collectors.toList() ).contains(
                         relationship.getId() ) )
                 {
                     // If deleted get the type from the transaction data. (?)
-                    types.addAll(  StreamSupport.stream( tx.deletedRelationships().spliterator(), false ).filter( rel -> rel.getId() == relationship.getId() ).map( rel -> rel.getType().name() ).collect( Collectors.toList()) );
-
-                    // Also if deleted get the old value of uidKey
-                    entityUid = uidFunction.apply( updatedEntity.getId() );
+                    types.addAll(  StreamSupport.stream( txDataWrapper.getTransactionData().deletedRelationships().spliterator(), false ).filter( rel -> rel.getId() == relationship.getId() ).map( rel -> rel.getType().name() ).collect( Collectors.toList()) );
                 }
                 else
                 {
                     types.add( relationship.getType().name() );
-
-                    // If not deleted set the entityUid based which property was removed
-                    entityUid = (actionType.equals( ActionType.REMOVED ) && propertyKey.equals( uidKey ) ) ? uidFunction.apply( updatedEntity.getId() )
-                                                                                                           : (String) updatedEntity.getProperty( uidKey, Long.toString( updatedEntity.getId() ) );
                 }
 
             }
             else
             {
                 types.add( updatedEntity.getType().name() );
-                entityUid = (String) updatedEntity.getProperty( uidKey, Long.toString( updatedEntity.getId() ) );
             }
 
             for ( String type : types )
@@ -676,16 +502,14 @@ public class TransactionDataMap
         return propertyChanges.isEmpty() ? Collections.emptyMap() : propertyChanges;
     }
 
-    public static Map<String,Map<String,List<Map<String,Object>>>> assignedRelationshipPropertyMapByType( TransactionData tx, String uidKey )
+    public static Map<String,Map<String,List<Map<String,Object>>>> assignedRelationshipPropertyMapByType( TxDataWrapper txDataWrapper )
     {
-        return updatedRelationshipPropertyMapByType( tx, tx.assignedRelationshipProperties(), uidKey, ActionType.ADDED,
-                ( l ) -> getRelationshipUidFromPreviousCommit( tx, uidKey, l ) );
+        return updatedRelationshipPropertyMapByType( txDataWrapper, txDataWrapper.getTransactionData().assignedRelationshipProperties(), ActionType.ADDED );
     }
 
-    public static Map<String,Map<String,List<Map<String,Object>>>> removedRelationshipPropertyMapByType( TransactionData tx, String uidKey )
+    public static Map<String,Map<String,List<Map<String,Object>>>> removedRelationshipPropertyMapByType( TxDataWrapper txDataWrapper )
     {
-        return updatedRelationshipPropertyMapByType( tx, tx.removedRelationshipProperties(), uidKey, ActionType.REMOVED,
-                ( l ) -> getRelationshipUidFromPreviousCommit( tx, uidKey, l ) );
+        return updatedRelationshipPropertyMapByType( txDataWrapper, txDataWrapper.getTransactionData().removedRelationshipProperties(), ActionType.REMOVED );
     }
 
     private interface TransactionDataMapObject
@@ -899,27 +723,719 @@ public class TransactionDataMap
         }
     }
 
-    public static String getNodeUidFromPreviousCommit( TransactionData tx, String uidKey, Long id )
+    @JsonAutoDetect
+    @JsonIgnoreProperties( ignoreUnknown = true )
+    public static class UniqueIdentifier
     {
-        String result = StreamSupport.stream( tx.removedNodeProperties().spliterator(), true )
-                .filter( ( p ) -> p.key().equals( uidKey ) )
-                .filter( ( p ) -> p.entity().getId() == id ).map( ( p ) -> (String) p.previouslyCommitedValue() )
-                .collect( Collectors.joining() );
+        private String uidGroup = "";
+        private String uidKey = "";
+        private String uidValue = "";
 
-        return (result.isEmpty()) ? Long.toString( id ) : result;
+        public UniqueIdentifier()
+        {
+        }
+
+        public UniqueIdentifier( String uidValue )
+        {
+            this.uidValue = uidValue;
+        }
+
+        public UniqueIdentifier( String uidGroup, String uidKey, String uidValue )
+        {
+            this.uidGroup = uidGroup;
+            this.uidKey = uidKey;
+            this.uidValue = uidValue;
+        }
+
+        public String getUidGroup()
+        {
+            return uidGroup;
+        }
+
+        public void setUidGroup( String uidGroup )
+        {
+            this.uidGroup = uidGroup;
+        }
+
+        public String getUidKey()
+        {
+            return uidKey;
+        }
+
+        public void setUidKey( String uidKey )
+        {
+            this.uidKey = uidKey;
+        }
+
+        public String getUidValue()
+        {
+            return uidValue;
+        }
+
+        public void setUidValue( String uidValue )
+        {
+            this.uidValue = uidValue;
+        }
+
+        public String buildUidString()
+        {
+            return String.format( "`%s`:`%s`:`%s`", uidGroup, uidKey, uidValue );
+        }
     }
 
-    ;
-
-    public static String getRelationshipUidFromPreviousCommit( TransactionData tx, String uidKey, Long id )
+    public static UniqueIdentifier getNodeUidFromCurrentCommit( TxDataWrapper txDataWrapper, Node node )
     {
-        String result = StreamSupport.stream( tx.removedRelationshipProperties().spliterator(), true )
-                .filter( ( p ) -> p.key().equals( uidKey ) )
-                .filter( ( p ) -> p.entity().getId() == id ).map( ( p ) -> (String) p.previouslyCommitedValue() )
-                .collect( Collectors.joining() );
+        List<String> uidKeys = txDataWrapper.getUidKeys();
+        List<String> labels = txDataWrapper.getLabels();
 
-        return (result.isEmpty()) ? Long.toString( id ) : result;
+        String uidKeyUsed = "";
+        String nodeUid = Long.toString( node.getId() );
+
+        String labelUsed = "";
+
+        for ( String uidKey : uidKeys )
+        {
+            if ( node.hasProperty( uidKey ) )
+            {
+                nodeUid = (String) node.getProperty( uidKey, Long.toString( node.getId() ) );
+                uidKeyUsed = uidKey;
+                break;
+            }
+        }
+
+        for ( String label : labels )
+        {
+            if ( node.hasLabel( new LabelImpl( label ) ) )
+            {
+                labelUsed = label;
+                break;
+            }
+        }
+
+        // If none of the labels match then use the head label.
+        if ( labelUsed.isEmpty() )
+        {
+            if ( node.getLabels().iterator().hasNext() )
+            {
+                labelUsed = node.getLabels().iterator().next().name();
+            }
+        }
+
+        return new UniqueIdentifier( labelUsed, uidKeyUsed, nodeUid );
     }
 
-    ;
+    public static UniqueIdentifier getRelationshipUidFromCurrentCommit( TxDataWrapper txDataWrapper, Relationship relationship )
+    {
+        List<String> uidKeys = txDataWrapper.getUidKeys();
+
+        String uidKeyUsed = "";
+        String relationshipUid = Long.toString( relationship.getId() );
+
+        for ( String uidKey : uidKeys )
+        {
+            if ( relationship.hasProperty( uidKey ) )
+            {
+                relationshipUid = (String) relationship.getProperty( uidKey, Long.toString( relationship.getId() ) );
+                uidKeyUsed = uidKey;
+                break;
+            }
+        }
+
+        return new UniqueIdentifier( relationship.getType().name(), uidKeyUsed, relationshipUid );
+    }
+
+    public static UniqueIdentifier getNodeUidFromPreviousCommit( TxDataWrapper txDataWrapper, Long id )
+    {
+        Map<Long,List<PropertyEntry<Node>>> propertyEntriesCache = txDataWrapper.getRemovedNodePropertiesCache();
+        Map<Long,List<Label>> removedNodeLabelsCache = txDataWrapper.getRemovedNodeLabelsCache();
+
+        List<String> uidKeys = txDataWrapper.getUidKeys();
+        List<String> labels = txDataWrapper.getLabels();
+
+        String uidKeyUsed = "";
+        String uidValue = Long.toString( id );
+
+        String labelUsed = "";
+
+        boolean breakOuter = false;
+
+        for ( String uidKey : uidKeys )
+        {
+            for ( PropertyEntry<Node> p : propertyEntriesCache.getOrDefault( id, Collections.emptyList() ) )
+            {
+                if ( p.key().equals( uidKey ) )
+                {
+                    uidKeyUsed = uidKey;
+                    uidValue = (String) p.previouslyCommitedValue();
+                    breakOuter = true;
+                    break;
+                }
+            }
+            if ( breakOuter )
+            {
+                break;
+            }
+        }
+
+        breakOuter = false;
+
+        for ( String label : labels )
+        {
+            for ( Label l : removedNodeLabelsCache.getOrDefault( id, Collections.emptyList() ) )
+            {
+                if ( l.name().equals( label ) )
+                {
+                    labelUsed = label;
+                    breakOuter = true;
+                    break;
+                }
+            }
+            if ( breakOuter )
+            {
+                break;
+            }
+        }
+
+        // If labelUsed still empty then just use the head.
+        if ( labelUsed.isEmpty() )
+        {
+            for ( Label l : removedNodeLabelsCache.getOrDefault( id, Collections.emptyList() ) )
+            {
+                labelUsed = l.name();
+                break;
+            }
+        }
+
+        return new UniqueIdentifier( labelUsed, uidKeyUsed, uidValue );
+    }
+
+    public static UniqueIdentifier getRelationshipUidFromPreviousCommit( TxDataWrapper txDataWrapper, Long id )
+    {
+        Map<Long,List<PropertyEntry<Relationship>>> propertyEntriesCache = txDataWrapper.getRemovedRelationshipPropertiesCache();
+
+        List<String> uidKeys = txDataWrapper.getUidKeys();
+
+        String uidKeyUsed = "";
+        String uidValue = Long.toString( id );
+
+        String typeUsed = "";
+
+        boolean breakOuter = false;
+
+        for (String uidKey : uidKeys )
+        {
+            for ( PropertyEntry<Relationship> p : propertyEntriesCache.getOrDefault( id, Collections.emptyList() ) )
+            {
+                if ( p.key().equals( uidKey ) )
+                {
+                    uidKeyUsed = uidKey;
+                    uidValue = (String) p.previouslyCommitedValue();
+                    breakOuter = true;
+
+                    typeUsed = p.entity().getType().name();
+                    break;
+                }
+            }
+            if (breakOuter)
+            {
+                break;
+            }
+        }
+
+        return new UniqueIdentifier( typeUsed, uidKeyUsed, uidValue );
+    }
+
+    public static class TxDataWrapper
+    {
+        private final TransactionData transactionData;
+
+        private final Map<Long,List<PropertyEntry<Node>>> assignedNodePropertiesCache;
+        private final Map<Long,List<PropertyEntry<Node>>> removedNodePropertiesCache;
+
+        private final Map<Long,List<PropertyEntry<Relationship>>> assignedRelationshipPropertiesCache;
+        private final Map<Long,List<PropertyEntry<Relationship>>> removedRelationshipPropertiesCache;
+
+        private final Map<Long,List<Label>> assignedNodeLabelsCache;
+        private final Map<Long,List<Label>> removedNodeLabelsCache;
+
+        private final List<String> uidKeys;
+        private final List<String> labels;
+
+        private final Map<Long, Node> deletedNodesMap;
+        private final Map<Long, Node> createdNodesMap;
+        private final Map<Long, Node> updatedNodesMap;
+        private final Set<Long> allNodes;
+
+        private final Map<Long, Relationship> deletedRelationshipsMap;
+        private final Map<Long, Relationship> createdRelationshipsMap;
+        private final Map<Long, Relationship> updatedRelationshipsMap;
+        private final Set<Long> allRelationships;
+
+        private final Map<Long,String> nodeIdToUid = new HashMap<>();
+        private final Map<Long,String> relationshipIdToUid = new HashMap<>();
+
+
+        public TxDataWrapper(TransactionData transactionData, List<String> uidKeys, List<String> labels)
+        {
+            this.transactionData = transactionData;
+            this.uidKeys = uidKeys;
+            this.labels = labels;
+
+            // Nodes Setup
+            assignedNodePropertiesCache = StreamSupport.stream( transactionData.assignedNodeProperties().spliterator(), true ).collect( Collectors.groupingBy( x -> x.entity().getId() ) );
+            removedNodePropertiesCache = StreamSupport.stream( transactionData.removedNodeProperties().spliterator(), true ).collect( Collectors.groupingBy( x -> x.entity().getId() ) );
+
+            assignedNodeLabelsCache = StreamSupport.stream( transactionData.assignedLabels().spliterator(), true ).collect( Collectors.groupingBy( x -> x.node().getId(), Collectors.mapping( labelEntry -> labelEntry.label(), Collectors.toList() ) ) );
+            removedNodeLabelsCache = StreamSupport.stream( transactionData.removedLabels().spliterator(), true ).collect( Collectors.groupingBy( x -> x.node().getId(), Collectors.mapping( labelEntry -> labelEntry.label(), Collectors.toList() ) ) );
+
+            deletedNodesMap = StreamSupport.stream( transactionData.deletedNodes().spliterator(), false ).collect( Collectors.toMap( Node::getId, x -> x ) );
+            createdNodesMap = StreamSupport.stream( transactionData.createdNodes().spliterator(), false ).collect( Collectors.toMap( Node::getId, x -> x ) );
+
+
+            List<Node> updatedRemovedPropertiesNodes = StreamSupport.stream( transactionData.removedNodeProperties().spliterator(), false ).map( PropertyEntry::entity ).filter(
+                    n -> !deletedNodesMap.keySet().contains( n.getId() ) && !createdNodesMap.keySet().contains( n.getId() ) ).collect( Collectors.toList() );
+
+            List<Node> updatedAssignedPropertiesNodes = StreamSupport.stream( transactionData.assignedNodeProperties().spliterator(), false ).map( PropertyEntry::entity ).filter(
+                    n -> !deletedNodesMap.keySet().contains( n.getId() ) && !createdNodesMap.keySet().contains( n.getId() ) ).collect( Collectors.toList() );
+
+            List<Node> updatedRemovedLabelsNodes = StreamSupport.stream( transactionData.removedLabels().spliterator(), false ).map( LabelEntry::node ).filter(
+                    n -> !deletedNodesMap.keySet().contains( n.getId() ) && !createdNodesMap.keySet().contains( n.getId() ) ).collect( Collectors.toList() );
+
+            List<Node> updatedAssignedLabelsNodes = StreamSupport.stream( transactionData.assignedLabels().spliterator(), false ).map( LabelEntry::node ).filter(
+                    n -> !deletedNodesMap.keySet().contains( n.getId() ) && !createdNodesMap.keySet().contains( n.getId() ) ).collect( Collectors.toList() );
+
+            updatedNodesMap = Stream.of(updatedRemovedPropertiesNodes, updatedAssignedPropertiesNodes, updatedRemovedLabelsNodes, updatedAssignedLabelsNodes)
+                    .flatMap( Collection::stream)
+                    .collect( Collectors.toSet() )
+                    .stream()
+                    .collect(Collectors.toMap( Node::getId, n->n));
+
+
+            allNodes = Stream.of(createdNodesMap.keySet(), deletedNodesMap.keySet(), updatedNodesMap.keySet())
+                    .flatMap( Collection::stream)
+                    .collect(Collectors.toSet());
+
+            for (Long id : allNodes)
+            {
+                nodeIdToUid.put( id, calculateNodeUID( this, id ).buildUidString() );
+            }
+
+
+            // Relationships Setup
+            assignedRelationshipPropertiesCache = StreamSupport.stream( transactionData.assignedRelationshipProperties().spliterator(), true ).collect( Collectors.groupingBy( x -> x.entity().getId() ) );
+            removedRelationshipPropertiesCache = StreamSupport.stream( transactionData.removedRelationshipProperties().spliterator(), true ).collect( Collectors.groupingBy( x -> x.entity().getId() ) );
+
+            createdRelationshipsMap = StreamSupport.stream( transactionData.createdRelationships().spliterator(), false ).collect( Collectors.toMap( Relationship::getId, x -> x ) );
+            deletedRelationshipsMap = StreamSupport.stream( transactionData.deletedRelationships().spliterator(), false ).collect( Collectors.toMap( Relationship::getId, x -> x ) );
+
+            List<Relationship> updatedRemovedPropertiesRelationships = StreamSupport.stream( transactionData.removedRelationshipProperties().spliterator(), false ).map( PropertyEntry::entity ).filter(
+                    n -> !createdRelationshipsMap.keySet().contains( n.getId() ) && !deletedRelationshipsMap.keySet().contains( n.getId() ) ).collect( Collectors.toList() );
+
+            List<Relationship> updatedAssignedPropertiesRelationships = StreamSupport.stream( transactionData.assignedRelationshipProperties().spliterator(), false ).map( PropertyEntry::entity ).filter(
+                    n -> !createdRelationshipsMap.keySet().contains( n.getId() ) && !deletedRelationshipsMap.keySet().contains( n.getId() ) ).collect( Collectors.toList() );
+
+            updatedRelationshipsMap = Stream.of(updatedRemovedPropertiesRelationships, updatedAssignedPropertiesRelationships )
+                    .flatMap( Collection::stream)
+                    .collect( Collectors.toSet() )
+                    .stream()
+                    .collect(Collectors.toMap( Relationship::getId, n->n));
+
+            allRelationships = Stream.of(createdRelationshipsMap.keySet(), deletedRelationshipsMap.keySet(), updatedRelationshipsMap.keySet())
+                    .flatMap( Collection::stream)
+                    .collect(Collectors.toSet());
+
+            for (Long id : allRelationships)
+            {
+                relationshipIdToUid.put( id, calculateRelationshipUID( this, id ).buildUidString() );
+            }
+
+        }
+
+        public String getNodeUid( Long id )
+        {
+            return nodeIdToUid.get( id );
+        }
+
+        public String getRelationshipUid( Long id )
+        {
+            return relationshipIdToUid.get( id );
+        }
+
+        public TransactionData getTransactionData()
+        {
+            return transactionData;
+        }
+
+        public Map<Long,List<PropertyEntry<Node>>> getRemovedNodePropertiesCache()
+        {
+            return removedNodePropertiesCache;
+        }
+
+        public Map<Long,List<PropertyEntry<Relationship>>> getRemovedRelationshipPropertiesCache()
+        {
+            return removedRelationshipPropertiesCache;
+        }
+
+        public Map<Long,List<Label>> getRemovedNodeLabelsCache()
+        {
+            return removedNodeLabelsCache;
+        }
+
+        public List<String> getUidKeys()
+        {
+            return uidKeys;
+        }
+
+        public List<String> getLabels()
+        {
+            return labels;
+        }
+
+        public Map<Long,Node> getDeletedNodesMap()
+        {
+            return deletedNodesMap;
+        }
+
+        public Map<Long,Node> getCreatedNodesMap()
+        {
+            return createdNodesMap;
+        }
+
+        public Map<Long,Node> getUpdatedNodesMap()
+        {
+            return updatedNodesMap;
+        }
+
+        public boolean isNodeDeleted( Long id )
+        {
+            return deletedNodesMap.containsKey( id );
+        }
+
+        public boolean isNodeCreated( Long id )
+        {
+            return createdNodesMap.containsKey( id );
+        }
+
+        public boolean isNodeUpdated( Long id )
+        {
+            return updatedNodesMap.containsKey( id );
+        }
+
+        public boolean isRelationshipDeleted( Long id )
+        {
+            return deletedRelationshipsMap.containsKey( id );
+        }
+
+        public boolean isRelationshipCreated( Long id )
+        {
+            return createdRelationshipsMap.containsKey( id );
+        }
+
+        public boolean isRelationshipUpdated( Long id )
+        {
+            return updatedRelationshipsMap.containsKey( id );
+        }
+
+        public Map<Long,List<Label>> getAssignedNodeLabelsCache()
+        {
+            return assignedNodeLabelsCache;
+        }
+
+        public Map<Long,List<PropertyEntry<Node>>> getAssignedNodePropertiesCache()
+        {
+            return assignedNodePropertiesCache;
+        }
+
+        public Map<Long,String> getNodeIdToUid()
+        {
+            return nodeIdToUid;
+        }
+
+        public Map<Long,List<PropertyEntry<Relationship>>> getAssignedRelationshipPropertiesCache()
+        {
+            return assignedRelationshipPropertiesCache;
+        }
+
+        public Set<Long> getAllNodes()
+        {
+            return allNodes;
+        }
+
+        public Set<Long> getAllRelationships()
+        {
+            return allRelationships;
+        }
+
+        public Map<Long,Relationship> getDeletedRelationshipsMap()
+        {
+            return deletedRelationshipsMap;
+        }
+
+        public Map<Long,Relationship> getCreatedRelationshipsMap()
+        {
+            return createdRelationshipsMap;
+        }
+
+        public Map<Long,Relationship> getUpdatedRelationshipsMap()
+        {
+            return updatedRelationshipsMap;
+        }
+
+        public Map<Long,String> getRelationshipIdToUid()
+        {
+            return relationshipIdToUid;
+        }
+    }
+
+    private static class LabelImpl implements Label
+    {
+        private String name;
+
+        public LabelImpl( String name )
+        {
+            this.name = name;
+        }
+
+        @Override
+        public String name()
+        {
+            return name;
+        }
+    }
+
+    public static UniqueIdentifier calculateNodeUID( TxDataWrapper txDataWrapper, Long id )
+    {
+
+        if ( txDataWrapper.isNodeCreated( id ) )
+        {
+            return getNodeUidFromCurrentCommit( txDataWrapper, txDataWrapper.getCreatedNodesMap().get( id ) );
+        }
+
+        if ( txDataWrapper.isNodeDeleted( id ) )
+        {
+            return getNodeUidFromPreviousCommit( txDataWrapper, id );
+        }
+
+        // Must be updated.
+        if ( !txDataWrapper.isNodeUpdated( id ) )
+        {
+            // Should never get here.
+        }
+
+        Node updatedNode = txDataWrapper.getUpdatedNodesMap().get( id );
+
+        // Labels, using previous commit so
+            // CAN use removed labels in labelList
+            // CAN'T use added labels in labelList
+            // CAN use unaffected labels in labelList
+
+        String labelUsed = "";
+        List<String> labelList = txDataWrapper.getLabels();
+
+        List<Label> allowableLabels = new ArrayList<>( txDataWrapper.getRemovedNodeLabelsCache().getOrDefault( id, new ArrayList<>() ) );
+        List<Label> restrictedLabels = new ArrayList<>( txDataWrapper.getAssignedNodeLabelsCache().getOrDefault( id, Collections.emptyList() ) );
+
+        // Allow any labels that has previously been on the node.
+        allowableLabels.addAll(
+                StreamSupport.stream( updatedNode.getLabels().spliterator(), false ).filter( label -> !restrictedLabels.contains( label ) ).collect(
+                        Collectors.toList() ) );
+
+        boolean breakOuter = false;
+        // Check if any of the labels in the labelList are on the node
+        for ( String label : labelList )
+        {
+            for ( Label l : allowableLabels )
+            {
+                if ( l.name().equals( label ) )
+                {
+                    labelUsed = label;
+                    breakOuter = true;
+                    break;
+                }
+            }
+            if ( breakOuter )
+            {
+                break;
+            }
+        }
+
+        // If labelUsed still empty then just use the head.
+        if ( labelUsed.isEmpty() && !allowableLabels.isEmpty() )
+        {
+            labelUsed = allowableLabels.get( 0 ).name();
+        }
+        // By this point labelUsed (uidGroup) has been set!
+
+        // Moving on to setting the uidKey and uidValue
+        List<String> uidKeys = txDataWrapper.getUidKeys();
+
+        String uidKeyUsed = "";
+        // Default uidValue to the id
+        String uidValue = Long.toString( id );
+
+
+
+        // Properties, using previous commit so
+            // CAN use removed properties
+            // CAN'T use newly added properties
+            // NEED to use OLD VALUE of any updated properties
+            // Can use unaffected properties
+
+        // Properties currently on the node.
+        List<String> currentProperties = StreamSupport.stream( updatedNode.getPropertyKeys().spliterator(), false ).collect( Collectors.toList() );
+
+        // Newly added properties
+        List<String> newProperties = txDataWrapper.getAssignedNodePropertiesCache().getOrDefault( id, Collections.emptyList() ).stream().filter(
+                pe -> pe.previouslyCommitedValue() == null ).map( PropertyEntry::key ).collect( Collectors.toList() );
+
+
+        // Properties previously on the node that were updated
+        Map<String,PropertyEntry<Node>> updatedProperties =
+                txDataWrapper.getAssignedNodePropertiesCache().getOrDefault( id, Collections.emptyList() ).stream().filter(
+                        pe -> !newProperties.contains( pe.key() ) ).collect( Collectors.toMap( PropertyEntry::key, x -> x ) );
+
+        // Properties previously on the node that were removed
+        Map<String,PropertyEntry<Node>> removedProperties =  txDataWrapper.getRemovedNodePropertiesCache().getOrDefault( id, Collections.emptyList() ).stream().collect( Collectors.toMap( PropertyEntry::key, x->x) );
+
+        List<String> allowableProperties = new ArrayList<>();
+        allowableProperties.addAll( updatedProperties.keySet() );
+        allowableProperties.addAll( removedProperties.keySet() );
+        allowableProperties.addAll( currentProperties.stream().filter( propKey -> !newProperties.contains( propKey ) ).collect( Collectors.toList() ) );
+
+        breakOuter = false;
+        for ( String uidKey : uidKeys )
+        {
+            for ( String propKey : allowableProperties )
+            {
+                if ( propKey.equals( uidKey ) )
+                {
+                    if ( updatedProperties.containsKey( propKey ) )
+                    {
+                        uidKeyUsed = propKey;
+                        uidValue = (String) updatedProperties.get( propKey ).previouslyCommitedValue();
+                        breakOuter = true;
+                        break;
+                    }
+                    else if ( removedProperties.containsKey( propKey ) )
+                    {
+                        uidKeyUsed = propKey;
+                        uidValue = (String) removedProperties.get( propKey ).previouslyCommitedValue();
+                        breakOuter = true;
+                        break;
+                    }
+                    else if ( currentProperties.contains( propKey ) )
+                    {
+                        uidKeyUsed = propKey;
+                        uidValue = (String) updatedNode.getProperty( propKey );
+                        breakOuter = true;
+                        break;
+                    }
+                }
+            }
+            if ( breakOuter )
+            {
+                break;
+            }
+        }
+
+        return new UniqueIdentifier( labelUsed, uidKeyUsed, uidValue );
+    }
+
+    public static UniqueIdentifier calculateRelationshipUID( TxDataWrapper txDataWrapper, Long id )
+    {
+
+        if ( txDataWrapper.isRelationshipCreated( id ) )
+        {
+            return getRelationshipUidFromCurrentCommit( txDataWrapper, txDataWrapper.getCreatedRelationshipsMap().get( id ) );
+        }
+
+        if ( txDataWrapper.isRelationshipDeleted( id ) )
+        {
+            return getRelationshipUidFromPreviousCommit( txDataWrapper, id );
+        }
+
+        // Must be updated.
+        if ( !txDataWrapper.isRelationshipUpdated( id ) )
+        {
+            // Should never get here.
+        }
+
+        Relationship updatedRelationship = txDataWrapper.getUpdatedRelationshipsMap().get( id );
+
+        // Relationship Type is Immutable
+        String typeUsed = updatedRelationship.getType().name();
+
+
+        // Moving on to setting the uidKey and uidValue
+        List<String> uidKeys = txDataWrapper.getUidKeys();
+
+        String uidKeyUsed = "";
+        // Default uidValue to the id
+        String uidValue = Long.toString( id );
+
+        // Properties, using previous commit so
+            // CAN use removed properties
+            // CAN'T use newly added properties
+            // NEED to use OLD VALUE of any updated properties
+            // Can use unaffected properties
+
+        // Properties currently on the node.
+        List<String> currentProperties = StreamSupport.stream( updatedRelationship.getPropertyKeys().spliterator(), false ).collect( Collectors.toList() );
+
+        // Newly added properties
+        List<String> newProperties = txDataWrapper.getAssignedRelationshipPropertiesCache().getOrDefault( id, Collections.emptyList() ).stream().filter(
+                pe -> pe.previouslyCommitedValue() == null ).map( PropertyEntry::key ).collect( Collectors.toList() );
+
+
+        // Properties previously on the node that were updated
+        Map<String,PropertyEntry<Relationship>> updatedProperties =
+                txDataWrapper.getAssignedRelationshipPropertiesCache().getOrDefault( id, Collections.emptyList() ).stream().filter(
+                        pe -> !newProperties.contains( pe.key() ) ).collect( Collectors.toMap( PropertyEntry::key, x -> x ) );
+
+        // Properties previously on the node that were removed
+        Map<String,PropertyEntry<Relationship>> removedProperties =  txDataWrapper.getRemovedRelationshipPropertiesCache().getOrDefault( id, Collections.emptyList() ).stream().collect( Collectors.toMap( PropertyEntry::key, x->x) );
+
+        List<String> allowableProperties = new ArrayList<>();
+        allowableProperties.addAll( updatedProperties.keySet() );
+        allowableProperties.addAll( removedProperties.keySet() );
+        allowableProperties.addAll( currentProperties.stream().filter( propKey -> !newProperties.contains( propKey ) ).collect( Collectors.toList() ) );
+
+        boolean breakOuter = false;
+        for ( String uidKey : uidKeys )
+        {
+            for ( String propKey : allowableProperties )
+            {
+                if ( propKey.equals( uidKey ) )
+                {
+                    if ( updatedProperties.containsKey( propKey ) )
+                    {
+                        uidKeyUsed = propKey;
+                        uidValue = (String) updatedProperties.get( propKey ).previouslyCommitedValue();
+                        breakOuter = true;
+                        break;
+                    }
+                    else if ( removedProperties.containsKey( propKey ) )
+                    {
+                        uidKeyUsed = propKey;
+                        uidValue = (String) removedProperties.get( propKey ).previouslyCommitedValue();
+                        breakOuter = true;
+                        break;
+                    }
+                    else if ( currentProperties.contains( propKey ) )
+                    {
+                        uidKeyUsed = propKey;
+                        uidValue = (String) updatedRelationship.getProperty( propKey );
+                        breakOuter = true;
+                        break;
+                    }
+                }
+            }
+            if ( breakOuter )
+            {
+                break;
+            }
+        }
+
+        return new UniqueIdentifier( typeUsed, uidKeyUsed, uidValue );
+    }
 }

--- a/src/main/java/apoc/trigger/Trigger.java
+++ b/src/main/java/apoc/trigger/Trigger.java
@@ -309,46 +309,50 @@ public class Trigger {
             Map<String,Object> txDataMap = new HashMap<>();
             GraphDatabaseService db = properties.getGraphDatabase();
 
-            String uidKey = (String) config.getOrDefault( "uidKey", "" );
+            List<String> uidKeys = (List<String>) config.getOrDefault( "uidKeys", Collections.emptyList() );
+            List<String> uidLabels = (List<String>) config.getOrDefault( "uidLabels", Collections.emptyList() );
 
             try ( Transaction tx = db.beginTx() )
             {
+
+                TransactionDataMap.TxDataWrapper txDataWrapper = new TransactionDataMap.TxDataWrapper( txData, uidKeys, uidLabels );
+
                 txDataMap.put( TRANSACTION_ID, phase.equals( "after" ) ? txData.getTransactionId() : -1 );
                 txDataMap.put( COMMIT_TIME, phase.equals( "after" ) ? txData.getCommitTime() : -1 );
 
-                txDataMap.put( CREATED_NODES, createdNodeMap(txData, uidKey ) );
-                txDataMap.put( CREATED_RELATIONSHIPS, createdRelationshipsMap( txData, uidKey ) );
+                txDataMap.put( CREATED_NODES, createdNodeMap( txDataWrapper ) );
+                txDataMap.put( CREATED_RELATIONSHIPS, createdRelationshipsMap( txDataWrapper ) );
 
-                txDataMap.put( DELETED_NODES, deletedNodeMap( txData, uidKey ) );
-                txDataMap.put( DELETED_RELATIONSHIPS, deletedRelationshipsMap( txData, uidKey ) );
+                txDataMap.put( DELETED_NODES, deletedNodeMap( txDataWrapper ) );
+                txDataMap.put( DELETED_RELATIONSHIPS, deletedRelationshipsMap( txDataWrapper ) );
 
-                txDataMap.put( ASSIGNED_LABELS, new HashMap<>(  ) );
-                ((Map<String,Object>) txDataMap.get( ASSIGNED_LABELS )).put( BY_LABEL, assignedLabelMapByLabel( txData, uidKey ) );
-                ((Map<String,Object>) txDataMap.get( ASSIGNED_LABELS )).put( BY_UID, assignedLabelMapByUid( txData, uidKey ) );
+                txDataMap.put( ASSIGNED_LABELS, new HashMap<>() );
+                ((Map<String,Object>) txDataMap.get( ASSIGNED_LABELS )).put( BY_LABEL, assignedLabelMapByLabel( txDataWrapper ) );
+                ((Map<String,Object>) txDataMap.get( ASSIGNED_LABELS )).put( BY_UID, assignedLabelMapByUid( txDataWrapper ) );
 
-                txDataMap.put( REMOVED_LABELS, new HashMap<>(  ) );
-                ((Map<String,Object>) txDataMap.get( REMOVED_LABELS )).put( BY_LABEL, removedLabelMapByLabel( txData, uidKey ) );
-                ((Map<String,Object>) txDataMap.get( REMOVED_LABELS )).put( BY_UID, removedLabelMapByUid( txData, uidKey ) );
+                txDataMap.put( REMOVED_LABELS, new HashMap<>() );
+                ((Map<String,Object>) txDataMap.get( REMOVED_LABELS )).put( BY_LABEL, removedLabelMapByLabel( txDataWrapper ) );
+                ((Map<String,Object>) txDataMap.get( REMOVED_LABELS )).put( BY_UID, removedLabelMapByUid( txDataWrapper ) );
 
-                txDataMap.put( ASSIGNED_NODE_PROPERTIES, new HashMap<>(  ) );
-                ((Map<String,Object>) txDataMap.get( ASSIGNED_NODE_PROPERTIES )).put( BY_LABEL, assignedNodePropertyMapByLabel( txData, uidKey ) );
-                ((Map<String,Object>) txDataMap.get( ASSIGNED_NODE_PROPERTIES )).put( BY_KEY, assignedNodePropertyMapByKey( txData, uidKey ) );
-                ((Map<String,Object>) txDataMap.get( ASSIGNED_NODE_PROPERTIES )).put( BY_UID, assignedNodePropertyMapByUid( txData, uidKey ) );
+                txDataMap.put( ASSIGNED_NODE_PROPERTIES, new HashMap<>() );
+                ((Map<String,Object>) txDataMap.get( ASSIGNED_NODE_PROPERTIES )).put( BY_LABEL, assignedNodePropertyMapByLabel( txDataWrapper ) );
+                ((Map<String,Object>) txDataMap.get( ASSIGNED_NODE_PROPERTIES )).put( BY_KEY, assignedNodePropertyMapByKey( txDataWrapper ) );
+                ((Map<String,Object>) txDataMap.get( ASSIGNED_NODE_PROPERTIES )).put( BY_UID, assignedNodePropertyMapByUid( txDataWrapper ) );
 
-                txDataMap.put( REMOVED_NODE_PROPERTIES, new HashMap<>(  ) );
-                ((Map<String,Object>) txDataMap.get( REMOVED_NODE_PROPERTIES )).put( BY_LABEL, removedNodePropertyMapByLabel( txData, uidKey ) );
-                ((Map<String,Object>) txDataMap.get( REMOVED_NODE_PROPERTIES )).put( BY_KEY, removedNodePropertyMapByKey( txData, uidKey ) );
-                ((Map<String,Object>) txDataMap.get( REMOVED_NODE_PROPERTIES )).put( BY_UID, removedNodePropertyMapByUid( txData, uidKey ) );
+                txDataMap.put( REMOVED_NODE_PROPERTIES, new HashMap<>() );
+                ((Map<String,Object>) txDataMap.get( REMOVED_NODE_PROPERTIES )).put( BY_LABEL, removedNodePropertyMapByLabel( txDataWrapper ) );
+                ((Map<String,Object>) txDataMap.get( REMOVED_NODE_PROPERTIES )).put( BY_KEY, removedNodePropertyMapByKey( txDataWrapper ) );
+                ((Map<String,Object>) txDataMap.get( REMOVED_NODE_PROPERTIES )).put( BY_UID, removedNodePropertyMapByUid( txDataWrapper ) );
 
-                txDataMap.put( ASSIGNED_RELATIONSHIP_PROPERTIES, new HashMap<>(  ) );
-                ((Map<String,Object>) txDataMap.get( ASSIGNED_RELATIONSHIP_PROPERTIES )).put( BY_TYPE, assignedRelationshipPropertyMapByType( txData, uidKey ) );
-                ((Map<String,Object>) txDataMap.get( ASSIGNED_RELATIONSHIP_PROPERTIES )).put( BY_KEY, assignedRelationshipPropertyMapByKey( txData, uidKey ) );
-                ((Map<String,Object>) txDataMap.get( ASSIGNED_RELATIONSHIP_PROPERTIES )).put( BY_UID, assignedRelationshipPropertyMapByUid( txData, uidKey ) );
+                txDataMap.put( ASSIGNED_RELATIONSHIP_PROPERTIES, new HashMap<>() );
+                ((Map<String,Object>) txDataMap.get( ASSIGNED_RELATIONSHIP_PROPERTIES )).put( BY_TYPE, assignedRelationshipPropertyMapByType( txDataWrapper ) );
+                ((Map<String,Object>) txDataMap.get( ASSIGNED_RELATIONSHIP_PROPERTIES )).put( BY_KEY, assignedRelationshipPropertyMapByKey( txDataWrapper ) );
+                ((Map<String,Object>) txDataMap.get( ASSIGNED_RELATIONSHIP_PROPERTIES )).put( BY_UID, assignedRelationshipPropertyMapByUid( txDataWrapper ) );
 
-                txDataMap.put( REMOVED_RELATIONSHIP_PROPERTIES, new HashMap<>(  ) );
-                ((Map<String,Object>) txDataMap.get( REMOVED_RELATIONSHIP_PROPERTIES )).put( BY_TYPE, removedRelationshipPropertyMapByType( txData, uidKey ) );
-                ((Map<String,Object>) txDataMap.get( REMOVED_RELATIONSHIP_PROPERTIES )).put( BY_KEY, removedRelationshipPropertyMapByKey( txData, uidKey ) );
-                ((Map<String,Object>) txDataMap.get( REMOVED_RELATIONSHIP_PROPERTIES )).put( BY_UID, removedRelationshipPropertyMapByUid( txData, uidKey ) );
+                txDataMap.put( REMOVED_RELATIONSHIP_PROPERTIES, new HashMap<>() );
+                ((Map<String,Object>) txDataMap.get( REMOVED_RELATIONSHIP_PROPERTIES )).put( BY_TYPE, removedRelationshipPropertyMapByType( txDataWrapper ) );
+                ((Map<String,Object>) txDataMap.get( REMOVED_RELATIONSHIP_PROPERTIES )).put( BY_KEY, removedRelationshipPropertyMapByKey( txDataWrapper ) );
+                ((Map<String,Object>) txDataMap.get( REMOVED_RELATIONSHIP_PROPERTIES )).put( BY_UID, removedRelationshipPropertyMapByUid( txDataWrapper ) );
 
                 tx.success();
             }


### PR DESCRIPTION
Changes to the txData object to update the UID keys used to identify nodes and relationships.

The parameters for the trigger controlling the UID generated in the txData are 'uidKeys' and 'uidLabels'. If a node does not have a label in the uidLabels list then it will use its first label. If a node/rel does not have a property in uidKeys then it will automatically use the node/rel id.

The format of the UIDs used are:
```
`label/type`:`propertyKey`:`propertyValue`
```