### PR TITLE
story - 3.4 - threadLogging

### DIFF
--- a/src/main/java/apoc/ApocKernelExtensionFactory.java
+++ b/src/main/java/apoc/ApocKernelExtensionFactory.java
@@ -82,6 +82,7 @@ public class ApocKernelExtensionFactory extends KernelExtensionFactory<ApocKerne
         public void start() throws Throwable {
             ApocConfiguration.initialize(db);
             Pools.NEO4J_SCHEDULER = dependencies.scheduler();
+            ThreadPoolExecutorLogger.LOG = log.getUserLog( ThreadPoolExecutorLogger.class );
             registerCustomProcedures();
             ttlLifeCycle = new TTLLifeCycle(Pools.NEO4J_SCHEDULER, db, log.getUserLog(TTLLifeCycle.class));
             ttlLifeCycle.start();

--- a/src/main/java/apoc/ThreadPoolExecutorLogger.java
+++ b/src/main/java/apoc/ThreadPoolExecutorLogger.java
@@ -1,0 +1,74 @@
+package apoc;
+
+import org.neo4j.logging.Log;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class ThreadPoolExecutorLogger extends ThreadPoolExecutor
+{
+    public static Log LOG;
+    private Boolean debugLog;
+    private String poolName;
+
+    public ThreadPoolExecutorLogger( int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue,
+            String poolName, Boolean threadPoolDebug )
+    {
+        super( corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue );
+        this.poolName = poolName;
+        this.debugLog = threadPoolDebug;
+    }
+
+    public ThreadPoolExecutorLogger( int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue,
+            RejectedExecutionHandler handler, String poolName, Boolean threadPoolDebug )
+    {
+        super( corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler );
+        this.poolName = poolName;
+        this.debugLog = threadPoolDebug;
+    }
+
+    @Override
+    protected void beforeExecute( Thread t, Runnable r )
+    {
+        if ( LOG != null && debugLog )
+        {
+            LOG.debug( "BeforeExecute Logging:\n" +
+                    "Pool: " + this.poolName + "\n" +
+                    "Active Thread Count: " + this.getActiveCount() + "\n" +
+                    "Thread Name: " + t.getName() + "\n" +
+                    "Thread Id: " + t.getId() + "\n" +
+                    "Thread Priority: " + t.getPriority() + "\n"
+            );
+        }
+        super.beforeExecute( t, r );
+    }
+
+    public Log getLog()
+    {
+        return LOG;
+    }
+
+    public void setLog( Log log )
+    {
+        this.LOG = log;
+    }
+
+    public Map<String,Object> getInfo()
+    {
+        Map<String,Object> loggingResult = new HashMap<>(  );
+        loggingResult.put( "poolName", poolName );
+        loggingResult.put( "activeCount", this.getActiveCount() );
+        loggingResult.put( "corePoolSize", this.getCorePoolSize() );
+        loggingResult.put( "poolSize", this.getPoolSize() );
+        loggingResult.put( "largestPoolSize", this.getLargestPoolSize() );
+        loggingResult.put( "maximumPoolSize", this.getMaximumPoolSize() );
+        loggingResult.put( "taskCount", this.getTaskCount() );
+        loggingResult.put( "completedTaskCount", this.getCompletedTaskCount() );
+
+        return loggingResult;
+    }
+}

--- a/src/main/java/apoc/log/Logging.java
+++ b/src/main/java/apoc/log/Logging.java
@@ -1,6 +1,9 @@
 package apoc.log;
 
 import apoc.ApocConfiguration;
+import apoc.Pools;
+import apoc.ThreadPoolExecutorLogger;
+import apoc.result.MapResult;
 import apoc.util.SimpleRateLimiter;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
@@ -9,7 +12,9 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 /**
  * @author bradnussbaum
@@ -68,6 +73,17 @@ public class Logging {
         log((logMessage) -> log.debug(logMessage), message, params);
     }
 
+    @Procedure
+    @Description( "apoc.log.threadPools() - logs threading info." )
+    public Stream<MapResult> threadPools()
+    {
+        Map<String,Object> singleInfo = ((ThreadPoolExecutorLogger) Pools.SINGLE).getInfo();
+        Map<String,Object> defaultInfo = ((ThreadPoolExecutorLogger) Pools.DEFAULT).getInfo();
+        Map<String,Object> brokerInfo = ((ThreadPoolExecutorLogger) Pools.BROKER).getInfo();
+
+        return Stream.of( new MapResult( singleInfo ), new MapResult( defaultInfo ), new MapResult( brokerInfo ) );
+    }
+
     public String format(String message, List<Object> params) { // visible for testing
         if (canLog()) {
             String formattedMessage = String.format(message, params.isEmpty() ? new Object[0] : params.toArray(new Object[params.size()]));
@@ -92,5 +108,4 @@ public class Logging {
         }
         return RATE_LIMITER.canExecute();
     }
-
 }


### PR DESCRIPTION
Adds two different way of thread logging. First, adds procedure 'apoc.log.threadPools' to gather thread pool information. Second, adds individual thread debug logging by overriding the ExecutorService 'beforeExecute' method. Individual thread debugging must be turned on through the neo4j.conf.