### PR TITLE
Story 3.4 access last tx

### DIFF
--- a/src/main/java/apoc/trigger/Trigger.java
+++ b/src/main/java/apoc/trigger/Trigger.java
@@ -10,12 +10,14 @@ import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.impl.core.EmbeddedProxySPI;
 import org.neo4j.kernel.impl.core.GraphProperties;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.*;
 
+import java.lang.reflect.Field;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -274,6 +276,19 @@ public class Trigger {
                     if (phase.equals( "after" ))
                     {
                         params.putAll( txDataCollector( txData, phase, (Map<String,Object>) data.get( "config" ) ) );
+
+                        try
+                        {
+                            Field f = txData.getClass().getDeclaredField( "transaction" );
+                            f.setAccessible( true );
+                            KernelTransaction kernelTransaction = (KernelTransaction) f.get( txData );
+                            params.put( "lastTxId", kernelTransaction.lastTransactionIdWhenStarted() );
+                            f.setAccessible( false );
+                        }
+                        catch ( NoSuchFieldException | IllegalAccessException e )
+                        {
+                            log.error( "Failed to get last transaction id: " + e.getMessage() );
+                        }
                     }
                     if( ( (Map<String,Object>) data.get( "config" )).get( "params" ) != null)
                     {

--- a/src/test/java/apoc/trigger/TriggerDataTest.java
+++ b/src/test/java/apoc/trigger/TriggerDataTest.java
@@ -58,6 +58,16 @@ public class TriggerDataTest
     }
 
     @Test
+    public void testTriggerData_lastTxId() {
+        db.execute("CALL apoc.trigger.add('test','WITH {createdNodes} AS createdNodes, {lastTxId} AS lastTxId UNWIND {createdNodes} AS n SET n.testProp = lastTxId',{phase: 'after'}, { uidKeys: ['uid'], params: {}})").close();
+        db.execute("CREATE (f:Foo {name:'Michael'})").close();
+        TestUtil.testCall(db, "MATCH (f:Foo) RETURN f", (row) -> {
+            assertEquals(true, ((Node)row.get("f")).hasProperty("testProp"));
+            assertNotEquals( "``:``:`0`", ((Node)row.get("f")).getProperty( "testProp") );
+        });
+    }
+
+    @Test
     public void testTriggerData_CommitTime() throws Exception {
         db.execute("CALL apoc.trigger.add('test','WITH {createdNodes} AS createdNodes, {txData} AS txData UNWIND {createdNodes} AS n SET n.testProp = txData." + COMMIT_TIME + "',{phase: 'after'}, { uidKeys: ['uid'], params: {}})").close();
         db.execute("CREATE (f:Foo {name:'Michael'})").close();


### PR DESCRIPTION
Fixes #41 

Adds `{lastTxId}` to the params available to triggers.

## Proposed Changes

Uses reflection to make the `TransactionData.transaction` field visible.
This is a `KernelTransaction` object, which contains the field `lastTransactionIdWhenStarted`.
This value of `TransactionData.transaction.lastTransactionIdWhenStarted` is then added to the params that can be used in a trigger's Cypher.