### PR TITLE
4.0 fix tests in TriggerDataTest

### DIFF
--- a/src/test/java/apoc/trigger/TriggerDataTest.java
+++ b/src/test/java/apoc/trigger/TriggerDataTest.java
@@ -28,6 +28,7 @@ import static apoc.trigger.TransactionDataMap.REMOVED_RELATIONSHIP_PROPERTIES;
 import static apoc.trigger.TransactionDataMap.TRANSACTION_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TriggerDataTest
 {
@@ -38,7 +39,7 @@ public class TriggerDataTest
             .withSetting(apoc_trigger_enabled, true);  // need to use settings here, apocConfig().setProperty in `setUp` is too late
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         start = System.currentTimeMillis();
         TestUtil.registerProcedure(db, Trigger.class);
         TestUtil.registerProcedure(db, Static.class);
@@ -49,329 +50,462 @@ public class TriggerDataTest
         if (db!=null) db.shutdown();
     }
 
-//    @Test
-    public void testTriggerData_TransactionId() throws Exception {
-        db.executeTransactionally( "CALL apoc.trigger.add('test','WITH {createdNodes} AS createdNodes, {txData} AS txData UNWIND {createdNodes} AS n SET n.testProp = txData." + TRANSACTION_ID + "',{phase: 'after'}, { params: {uidKeys: ['uid']}})");
+    @Test
+    public void testTriggerData_TransactionId() {
+        db.executeTransactionally( "CALL apoc.trigger.add('test','WITH $createdNodes AS createdNodes, $txData AS txData UNWIND $createdNodes AS n SET n.testProp = txData." + TRANSACTION_ID + "',{phase: 'after'}, { params: {uidKeys: ['uid']}})");
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})");
         TestUtil.testCall(db, "MATCH (f:Foo) RETURN f", (row) -> {
-            assertEquals(true, ((Node)row.get("f")).hasProperty("testProp"));
-            assertNotEquals( "0", ((Node)row.get("f")).getProperty( "testProp") );
+            assertTrue( ((Node) row.get( "f" )).hasProperty( "testProp" ) );
+            assertNotEquals( -1L, ((Node)row.get("f")).getProperty( "testProp") );
         });
     }
 
-//    @Test
-    public void testTriggerData_CommitTime() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {createdNodes} AS createdNodes, {txData} AS txData UNWIND {createdNodes} AS n SET n.testProp = txData." + COMMIT_TIME + "',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+    @Test
+    public void testTriggerData_CommitTime() {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $createdNodes AS createdNodes, $txData AS txData UNWIND $createdNodes AS n SET n.testProp = txData." + COMMIT_TIME + "',{phase: 'after'}, { params: {uidKeys: ['uid']}})");
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})");
         TestUtil.testCall(db, "MATCH (f:Foo) RETURN f", (row) -> {
-            assertEquals(true, ((Node)row.get("f")).hasProperty("testProp"));
-            assertNotEquals( "0", ((Node)row.get("f")).getProperty( "testProp") );
+            assertTrue( ((Node) row.get( "f" )).hasProperty( "testProp" ) );
+            assertNotEquals( -1L, ((Node)row.get("f")).getProperty( "testProp") );
         });
     }
 
-//    @Test
-    public void testTriggerData_CreatedNodes() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {createdNodes} AS createdNodes, {txData} AS txData UNWIND {createdNodes} AS n SET n.testProp = keys(txData." + CREATED_NODES + ")[0]',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+    private void testTriggerData_CreatedNodes( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $createdNodes AS createdNodes, $txData AS txData UNWIND $createdNodes AS n SET n.testProp = keys(txData." + CREATED_NODES + ")[0]',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1'})");
         TestUtil.testCall(db, "MATCH (f:Foo) RETURN f", (row) -> {
-            assertEquals(true, ((Node)row.get("f")).hasProperty("testProp"));
-            assertEquals( "uid-node-1", ((Node)row.get("f")).getProperty( "testProp") );
+            assertTrue( ((Node) row.get( "f" )).hasProperty( "testProp" ) );
+            assertEquals( "`Foo`:`uid`:`uid-node-1`", ((Node)row.get("f")).getProperty( "testProp") );
         });
     }
 
-//    @Test
-    public void testTriggerData_DeletedNodes() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData}  AS txData UNWIND keys(txData." + DELETED_NODES + ") AS key CALL apoc.static.set(\\'testProp\\', key) YIELD value RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+    @Test
+    public void testTriggerData_CreatedNodes_before() {
+        testTriggerData_CreatedNodes( "before" );
+    }
+
+    @Test
+    public void testTriggerData_CreatedNodes_after() {
+        testTriggerData_CreatedNodes( "after" );
+    }
+
+    private void testTriggerData_DeletedNodes( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData  AS txData UNWIND keys(txData." + DELETED_NODES + ") AS key CALL apoc.static.set(\\'testProp\\', key) YIELD value RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1'})");
         db.executeTransactionally("MATCH (f:Foo) WHERE f.uid = 'uid-node-1' DELETE f");
-        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> {
-            assertEquals("uid-node-1", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> assertEquals("`Foo`:`uid`:`uid-node-1`", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_CreatedRelationships() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {createdRelationships} AS createdRelationships, {txData} AS txData UNWIND {createdRelationships} AS r SET r.testProp = keys(txData." + CREATED_RELATIONSHIPS + ")[0]',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+    @Test
+    public void testTriggerData_DeletedNodes_before() {
+        testTriggerData_DeletedNodes( "before" );
+    }
+
+    @Test
+    public void testTriggerData_DeletedNodes_after() {
+        testTriggerData_DeletedNodes( "after" );
+    }
+
+    private void testTriggerData_CreatedRelationships( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $createdRelationships AS createdRelationships, $txData AS txData UNWIND $createdRelationships AS r SET r.testProp = keys(txData." + CREATED_RELATIONSHIPS + ")[0]',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})-[r:BAR {uid:'uid-rel-1'}]->(g:Foo {name:'John'})");
         TestUtil.testCall(db, "MATCH (f:Foo)-[r:BAR]->(g:Foo) RETURN r", (row) -> {
-            assertEquals(true, ((Relationship)row.get("r")).hasProperty("testProp"));
-            assertEquals( "uid-rel-1", ((Relationship)row.get("r")).getProperty( "testProp") );
+            assertTrue( ((Relationship) row.get( "r" )).hasProperty( "testProp" ) );
+            assertEquals( "`BAR`:`uid`:`uid-rel-1`", ((Relationship)row.get("r")).getProperty( "testProp") );
         });
     }
 
-//    @Test
-    public void testTriggerData_DeletedRelationships() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData}  AS txData UNWIND keys(txData." + DELETED_RELATIONSHIPS + ") AS key CALL apoc.static.set(\\'testProp\\', key) YIELD value RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+    @Test
+    public void testTriggerData_CreatedRelationships_before() {
+        testTriggerData_CreatedRelationships( "before" );
+    }
+
+    @Test
+    public void testTriggerData_CreatedRelationships_after() {
+        testTriggerData_CreatedRelationships( "after" );
+    }
+
+    private void testTriggerData_DeletedRelationships( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData  AS txData UNWIND keys(txData." + DELETED_RELATIONSHIPS + ") AS key CALL apoc.static.set(\\'testProp\\', key) YIELD value RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})-[r:BAR {uid:'uid-rel-1'}]->(g:Foo {name:'John'})");
         db.executeTransactionally("MATCH (f:Foo)-[r:BAR]-(g:Foo) DELETE r");
-        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> {
-            assertEquals("uid-rel-1", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> assertEquals("`BAR`:`uid`:`uid-rel-1`", row.get("value") ) );
     }
 
+    @Test
+    public void testTriggerData_DeletedRelationships_before() {
+        testTriggerData_DeletedRelationships( "before" );
+    }
 
-//    @Test
-    public void testTriggerData_AssignedLabels_ByLabel() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData CALL apoc.static.set(\\'testProp\\', txData." + ASSIGNED_LABELS + ".byLabel.Foo[0].nodeUid) YIELD value RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+    @Test
+    public void testTriggerData_DeletedRelationships_after() {
+        testTriggerData_DeletedRelationships( "after" );
+    }
+
+    private void testTriggerData_AssignedLabels_ByLabel( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData CALL apoc.static.set(\\'testProp\\', txData." + ASSIGNED_LABELS + ".byLabel.Foo[0].nodeUid) YIELD value RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1'})");
-        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> {
-            assertEquals("uid-node-1", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> assertEquals("`Foo`:`uid`:`uid-node-1`", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_AssignedLabels_ByUid() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData CALL apoc.static.set(\\'testProp\\', keys(txData." + ASSIGNED_LABELS + ".byUid)[0]) YIELD value RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+    @Test
+    public void testTriggerData_AssignedLabels_ByLabel_before() {
+        testTriggerData_AssignedLabels_ByLabel( "before" );
+    }
+
+    @Test
+    public void testTriggerData_AssignedLabels_ByLabel_after() {
+        testTriggerData_AssignedLabels_ByLabel( "after" );
+    }
+
+    private void testTriggerData_AssignedLabels_ByUid( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData CALL apoc.static.set(\\'testProp\\', keys(txData." + ASSIGNED_LABELS + ".byUid)[0]) YIELD value RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1'})");
-        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> {
-            assertEquals("uid-node-1", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> assertEquals("`Foo`:`uid`:`uid-node-1`", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_RemovedLabels_ByLabel() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData CALL apoc.static.set(\\'testProp\\', txData." + REMOVED_LABELS + ".byLabel.Foo[0].nodeUid) YIELD value RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+    @Test
+    public void testTriggerData_AssignedLabels_ByUid_before() {
+        testTriggerData_AssignedLabels_ByUid( "before" );
+    }
+
+    @Test
+    public void testTriggerData_AssignedLabels_ByUid_after() {
+        testTriggerData_AssignedLabels_ByUid( "after" );
+    }
+
+    private void testTriggerData_RemovedLabels_ByLabel( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData CALL apoc.static.set(\\'testProp\\', txData." + REMOVED_LABELS + ".byLabel.Foo[0].nodeUid) YIELD value RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1'})");
         db.executeTransactionally("MATCH (f:Foo) WHERE f.uid = 'uid-node-1' DELETE f");
-        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> {
-            assertEquals("uid-node-1", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> assertEquals("`Foo`:`uid`:`uid-node-1`", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_RemovedLabels_ByUid() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData CALL apoc.static.set(\\'testProp\\', keys(txData." + REMOVED_LABELS + ".byUid)[0]) YIELD value RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+    @Test
+    public void testTriggerData_RemovedLabels_ByLabel_before() {
+        testTriggerData_RemovedLabels_ByLabel( "before" );
+    }
+
+    @Test
+    public void testTriggerData_RemovedLabels_ByLabel_after() {
+        testTriggerData_RemovedLabels_ByLabel( "after" );
+    }
+
+    private void testTriggerData_RemovedLabels_ByUid( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData CALL apoc.static.set(\\'testProp\\', keys(txData." + REMOVED_LABELS + ".byUid)[0]) YIELD value RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1'})");
         db.executeTransactionally("MATCH (f:Foo) WHERE f.uid = 'uid-node-1' DELETE f");
-        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> {
-            assertEquals("uid-node-1", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('testProp') YIELD value RETURN value", (row) -> assertEquals("`Foo`:`uid`:`uid-node-1`", row.get("value") ) );
     }
     
-//    @Test
-    public void testTriggerData_AssignedNodeProperties_ByLabel() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + ASSIGNED_NODE_PROPERTIES + ".byLabel.Foo.`uid-node-1`[0] AS props" +
+    @Test
+    public void testTriggerData_RemovedLabels_ByUid_before() {
+        testTriggerData_RemovedLabels_ByUid( "before" );
+    }
+
+    @Test
+    public void testTriggerData_RemovedLabels_ByUid_after() {
+        testTriggerData_RemovedLabels_ByUid( "after" );
+    }
+
+    private void testTriggerData_AssignedNodeProperties_ByLabel( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + ASSIGNED_NODE_PROPERTIES + ".byLabel[\\'Foo\\'][\\'`Foo`:`uid`:`uid-node-1`\\'][0] AS props" +
                 " WITH props.key AS keyProp, props.value AS valueProp" +
                 " CALL apoc.static.set(\\'keyProp\\', keyProp) YIELD value" +
                 " WITH valueProp, value AS v1" +
                 " CALL apoc.static.set(\\'valueProp\\', valueProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1'})");
         db.executeTransactionally("MATCH (f:Foo {name:'Michael', uid: 'uid-node-1'}) SET f.color = 'blue'");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> {
-            assertEquals("color", ((String)row.get("value")));
-        });
-        TestUtil.testCall(db, "CALL apoc.static.get('valueProp') YIELD value RETURN value", (row) -> {
-            assertEquals("blue", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> assertEquals("color", row.get("value") ) );
+        TestUtil.testCall(db, "CALL apoc.static.get('valueProp') YIELD value RETURN value", (row) -> assertEquals("blue", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_AssignedNodeProperties_ByKey() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + ASSIGNED_NODE_PROPERTIES + ".byKey.color[0] AS uidProp" +
+    @Test
+    public void testTriggerData_AssignedNodeProperties_ByLabel_before() {
+        testTriggerData_AssignedNodeProperties_ByLabel( "before" );
+    }
+
+    @Test
+    public void testTriggerData_AssignedNodeProperties_ByLabel_after() {
+        testTriggerData_AssignedNodeProperties_ByLabel( "after" );
+    }
+
+    private void testTriggerData_AssignedNodeProperties_ByKey( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + ASSIGNED_NODE_PROPERTIES + ".byKey.color[0] AS uidProp" +
                 " CALL apoc.static.set(\\'uidProp\\', uidProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1'})");
         db.executeTransactionally("MATCH (f:Foo {name:'Michael', uid: 'uid-node-1'}) SET f.color = 'blue'");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('uidProp') YIELD value RETURN value", (row) -> {
-            assertEquals("uid-node-1", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('uidProp') YIELD value RETURN value", (row) -> assertEquals("`Foo`:`uid`:`uid-node-1`", row.get("value") ) );
     }
     
-//    @Test
-    public void testTriggerData_AssignedNodeProperties_ByUid() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + ASSIGNED_NODE_PROPERTIES + ".byUid.`uid-node-1`[0] AS props" +
+    @Test
+    public void testTriggerData_AssignedNodeProperties_ByKey_before() {
+        testTriggerData_AssignedNodeProperties_ByKey( "before" );
+    }
+
+    @Test
+    public void testTriggerData_AssignedNodeProperties_ByKey_after() {
+        testTriggerData_AssignedNodeProperties_ByKey( "after" );
+    }
+
+    private void testTriggerData_AssignedNodeProperties_ByUid( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + ASSIGNED_NODE_PROPERTIES + ".byUid[\\'`Foo`:`uid`:`uid-node-1`\\'][0] AS props" +
                 " WITH props.key AS keyProp, props.value AS valueProp" +
                 " CALL apoc.static.set(\\'keyProp\\', keyProp) YIELD value" +
                 " WITH valueProp, value AS v1" +
                 " CALL apoc.static.set(\\'valueProp\\', valueProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1'})");
         db.executeTransactionally("MATCH (f:Foo {name:'Michael', uid: 'uid-node-1'}) SET f.color = 'blue'");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> {
-            assertEquals("color", ((String)row.get("value")));
-        });
-        TestUtil.testCall(db, "CALL apoc.static.get('valueProp') YIELD value RETURN value", (row) -> {
-            assertEquals("blue", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> assertEquals("color", row.get("value") ) );
+        TestUtil.testCall(db, "CALL apoc.static.get('valueProp') YIELD value RETURN value", (row) -> assertEquals("blue", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_RemovedNodeProperties_ByLabel() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + REMOVED_NODE_PROPERTIES + ".byLabel.Foo.`uid-node-1`[0] AS props" +
+    @Test
+    public void testTriggerData_AssignedNodeProperties_ByUid_before() {
+        testTriggerData_AssignedNodeProperties_ByUid("before");
+    }
+
+    @Test
+    public void testTriggerData_AssignedNodeProperties_ByUid_after() {
+        testTriggerData_AssignedNodeProperties_ByUid("after");
+    }
+
+    private void testTriggerData_RemovedNodeProperties_ByLabel( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + REMOVED_NODE_PROPERTIES + ".byLabel[\\'Foo\\'][\\'`Foo`:`uid`:`uid-node-1`\\'][0] AS props" +
                 " WITH props.key AS keyProp, props.oldValue AS oldValueProp" +
                 " CALL apoc.static.set(\\'keyProp\\', keyProp) YIELD value" +
                 " WITH oldValueProp, value AS v1" +
                 " CALL apoc.static.set(\\'oldValueProp\\', oldValueProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1', color: 'blue'})");
         db.executeTransactionally("MATCH (f:Foo {name:'Michael', uid: 'uid-node-1'}) REMOVE f.color");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> {
-            assertEquals("color", ((String)row.get("value")));
-        });
-        TestUtil.testCall(db, "CALL apoc.static.get('oldValueProp') YIELD value RETURN value", (row) -> {
-            assertEquals("blue", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> assertEquals("color", row.get("value") ) );
+        TestUtil.testCall(db, "CALL apoc.static.get('oldValueProp') YIELD value RETURN value", (row) -> assertEquals("blue", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_RemovedNodeProperties_ByKey() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + REMOVED_NODE_PROPERTIES + ".byKey.color[0] AS uidProp" +
+    @Test
+    public void testTriggerData_RemovedNodeProperties_ByLabel_before() {
+        testTriggerData_RemovedNodeProperties_ByLabel("before");
+    }
+
+    @Test
+    public void testTriggerData_RemovedNodeProperties_ByLabel_after() {
+        testTriggerData_RemovedNodeProperties_ByLabel("after");
+    }
+
+    private void testTriggerData_RemovedNodeProperties_ByKey( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + REMOVED_NODE_PROPERTIES + ".byKey.color[0] AS uidProp" +
                 " CALL apoc.static.set(\\'uidProp\\', uidProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1', color: 'blue'})");
         db.executeTransactionally("MATCH (f:Foo {name:'Michael', uid: 'uid-node-1'}) REMOVE f.color");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('uidProp') YIELD value RETURN value", (row) -> {
-            assertEquals("uid-node-1", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('uidProp') YIELD value RETURN value", (row) -> assertEquals("`Foo`:`uid`:`uid-node-1`", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_RemovedNodeProperties_ByUid() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + REMOVED_NODE_PROPERTIES + ".byUid.`uid-node-1`[0] AS props" +
+    @Test
+    public void testTriggerData_RemovedNodeProperties_ByKey_before() {
+        testTriggerData_RemovedNodeProperties_ByKey("before");
+    }
+
+    @Test
+    public void testTriggerData_RemovedNodeProperties_ByKey_after() {
+        testTriggerData_RemovedNodeProperties_ByKey("after");
+    }
+
+    private void testTriggerData_RemovedNodeProperties_ByUid( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + REMOVED_NODE_PROPERTIES + ".byUid[\\'`Foo`:`uid`:`uid-node-1`\\'][0] AS props" +
                 " WITH props.key AS keyProp, props.oldValue AS oldValueProp" +
                 " CALL apoc.static.set(\\'keyProp\\', keyProp) YIELD value" +
                 " WITH oldValueProp, value AS v1" +
                 " CALL apoc.static.set(\\'oldValueProp\\', oldValueProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael', uid: 'uid-node-1', color: 'blue'})");
         db.executeTransactionally("MATCH (f:Foo {name:'Michael', uid: 'uid-node-1'}) REMOVE f.color");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> {
-            assertEquals("color", ((String)row.get("value")));
-        });
-        TestUtil.testCall(db, "CALL apoc.static.get('oldValueProp') YIELD value RETURN value", (row) -> {
-            assertEquals("blue", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> assertEquals("color", row.get("value") ) );
+        TestUtil.testCall(db, "CALL apoc.static.get('oldValueProp') YIELD value RETURN value", (row) -> assertEquals("blue", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_AssignedRelationshipProperties_ByType() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + ASSIGNED_RELATIONSHIP_PROPERTIES + ".byType.BAR.`uid-rel-1`[0] AS props" +
+    @Test
+    public void testTriggerData_RemovedNodeProperties_ByUid_before() {
+        testTriggerData_RemovedNodeProperties_ByUid("before");
+    }
+
+    @Test
+    public void testTriggerData_RemovedNodeProperties_ByUid_after() {
+        testTriggerData_RemovedNodeProperties_ByUid("after");
+    }
+
+    private void testTriggerData_AssignedRelationshipProperties_ByType( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + ASSIGNED_RELATIONSHIP_PROPERTIES + ".byType[\\'BAR\\'][\\'`BAR`:`uid`:`uid-rel-1`\\'][0] AS props" +
                 " WITH props.key AS keyProp, props.value AS valueProp" +
                 " CALL apoc.static.set(\\'keyProp\\', keyProp) YIELD value" +
                 " WITH valueProp, value AS v1" +
                 " CALL apoc.static.set(\\'valueProp\\', valueProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})-[r:BAR {uid:'uid-rel-1'}]->(g:Foo {name:'John'})");
         db.executeTransactionally("MATCH (f:Foo)-[r:BAR]->(g:Foo) SET r.color = 'red'");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> {
-            assertEquals("color", ((String)row.get("value")));
-        });
-        TestUtil.testCall(db, "CALL apoc.static.get('valueProp') YIELD value RETURN value", (row) -> {
-            assertEquals("red", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> assertEquals("color", row.get("value") ) );
+        TestUtil.testCall(db, "CALL apoc.static.get('valueProp') YIELD value RETURN value", (row) -> assertEquals("red", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_AssignedRelationshipProperties_ByKey() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + ASSIGNED_RELATIONSHIP_PROPERTIES + ".byKey.color[0] AS uidProp" +
+    @Test
+    public void testTriggerData_AssignedRelationshipProperties_ByType_before() {
+        testTriggerData_AssignedRelationshipProperties_ByType("before");
+    }
+
+    @Test
+    public void testTriggerData_AssignedRelationshipProperties_ByType_after() {
+        testTriggerData_AssignedRelationshipProperties_ByType("after");
+    }
+
+    private void testTriggerData_AssignedRelationshipProperties_ByKey( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + ASSIGNED_RELATIONSHIP_PROPERTIES + ".byKey.color[0] AS uidProp" +
                 " CALL apoc.static.set(\\'uidProp\\', uidProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})-[r:BAR {uid:'uid-rel-1'}]->(g:Foo {name:'John'})");
         db.executeTransactionally("MATCH (f:Foo)-[r:BAR]->(g:Foo) SET r.color = 'red'");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('uidProp') YIELD value RETURN value", (row) -> {
-            assertEquals("uid-rel-1", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('uidProp') YIELD value RETURN value", (row) -> assertEquals("`BAR`:`uid`:`uid-rel-1`", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_AssignedRelationshipProperties_ByUid() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + ASSIGNED_RELATIONSHIP_PROPERTIES + ".byUid.`uid-rel-1`[0] AS props" +
+    @Test
+    public void testTriggerData_AssignedRelationshipProperties_ByKey_before() {
+        testTriggerData_AssignedRelationshipProperties_ByKey("before");
+    }
+
+    @Test
+    public void testTriggerData_AssignedRelationshipProperties_ByKey_after() {
+        testTriggerData_AssignedRelationshipProperties_ByKey("after");
+    }
+
+    private void testTriggerData_AssignedRelationshipProperties_ByUid( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + ASSIGNED_RELATIONSHIP_PROPERTIES + ".byUid[\\'`BAR`:`uid`:`uid-rel-1`\\'][\\'propertyChanges\\'][0] AS props" +
                 " WITH props.key AS keyProp, props.value AS valueProp" +
                 " CALL apoc.static.set(\\'keyProp\\', keyProp) YIELD value" +
                 " WITH valueProp, value AS v1" +
                 " CALL apoc.static.set(\\'valueProp\\', valueProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})-[r:BAR {uid:'uid-rel-1'}]->(g:Foo {name:'John'})");
         db.executeTransactionally("MATCH (f:Foo)-[r:BAR]->(g:Foo) SET r.color = 'red'");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> {
-            assertEquals("color", ((String)row.get("value")));
-        });
-        TestUtil.testCall(db, "CALL apoc.static.get('valueProp') YIELD value RETURN value", (row) -> {
-            assertEquals("red", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> assertEquals("color", row.get("value") ) );
+        TestUtil.testCall(db, "CALL apoc.static.get('valueProp') YIELD value RETURN value", (row) -> assertEquals("red", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_RemovedRelationshipProperties_ByType() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + REMOVED_RELATIONSHIP_PROPERTIES + ".byType.BAR.`uid-rel-1`[0] AS props" +
+    @Test
+    public void testTriggerData_AssignedRelationshipProperties_ByUid_before() {
+        testTriggerData_AssignedRelationshipProperties_ByUid("before");
+    }
+
+    @Test
+    public void testTriggerData_AssignedRelationshipProperties_ByUid_after() {
+        testTriggerData_AssignedRelationshipProperties_ByUid("after");
+    }
+
+    private void testTriggerData_RemovedRelationshipProperties_ByType( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + REMOVED_RELATIONSHIP_PROPERTIES + ".byType[\\'BAR\\'][\\'`BAR`:`uid`:`uid-rel-1`\\'][0] AS props" +
                 " WITH props.key AS keyProp, props.oldValue AS oldValueProp" +
                 " CALL apoc.static.set(\\'keyProp\\', keyProp) YIELD value" +
                 " WITH oldValueProp, value AS v1" +
                 " CALL apoc.static.set(\\'oldValueProp\\', oldValueProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})-[r:BAR {uid:'uid-rel-1', color: 'red'}]->(g:Foo {name:'John'})");
         db.executeTransactionally("MATCH (f:Foo)-[r:BAR]->(g:Foo) REMOVE r.color");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> {
-            assertEquals("color", ((String)row.get("value")));
-        });
-        TestUtil.testCall(db, "CALL apoc.static.get('oldValueProp') YIELD value RETURN value", (row) -> {
-            assertEquals("red", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> assertEquals("color", row.get("value") ) );
+        TestUtil.testCall(db, "CALL apoc.static.get('oldValueProp') YIELD value RETURN value", (row) -> assertEquals("red", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_RemovedRelationshipProperties_ByKey() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + REMOVED_RELATIONSHIP_PROPERTIES + ".byKey.color[0] AS uidProp" +
+    @Test
+    public void testTriggerData_RemovedRelationshipProperties_ByType_before() {
+        testTriggerData_RemovedRelationshipProperties_ByType("before");
+    }
+
+    @Test
+    public void testTriggerData_RemovedRelationshipProperties_ByType_after() {
+        testTriggerData_RemovedRelationshipProperties_ByType("after");
+    }
+
+    private void testTriggerData_RemovedRelationshipProperties_ByKey( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + REMOVED_RELATIONSHIP_PROPERTIES + ".byKey.color[0] AS uidProp" +
                 " CALL apoc.static.set(\\'uidProp\\', uidProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})-[r:BAR {uid:'uid-rel-1', color: 'red'}]->(g:Foo {name:'John'})");
         db.executeTransactionally("MATCH (f:Foo)-[r:BAR]->(g:Foo) REMOVE r.color");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('uidProp') YIELD value RETURN value", (row) -> {
-            assertEquals("uid-rel-1", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('uidProp') YIELD value RETURN value", (row) -> assertEquals("`BAR`:`uid`:`uid-rel-1`", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_RemovedRelationshipProperties_ByUid() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData WITH txData, txData." + REMOVED_RELATIONSHIP_PROPERTIES + ".byUid.`uid-rel-1`[0] AS props" +
+    @Test
+    public void testTriggerData_RemovedRelationshipProperties_ByKey_before() {
+        testTriggerData_RemovedRelationshipProperties_ByKey("before");
+    }
+
+    @Test
+    public void testTriggerData_RemovedRelationshipProperties_ByKey_after() {
+        testTriggerData_RemovedRelationshipProperties_ByKey("after");
+    }
+
+    private void testTriggerData_RemovedRelationshipProperties_ByUid( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData WITH txData, txData." + REMOVED_RELATIONSHIP_PROPERTIES + ".byUid[\\'`BAR`:`uid`:`uid-rel-1`\\'][\\'propertyChanges\\'][0] AS props" +
                 " WITH props.key AS keyProp, props.oldValue AS oldValueProp" +
                 " CALL apoc.static.set(\\'keyProp\\', keyProp) YIELD value" +
                 " WITH oldValueProp, value AS v1" +
                 " CALL apoc.static.set(\\'oldValueProp\\', oldValueProp) YIELD value" +
-                " RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+                " RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})-[r:BAR {uid:'uid-rel-1', color: 'red'}]->(g:Foo {name:'John'})");
         db.executeTransactionally("MATCH (f:Foo)-[r:BAR]->(g:Foo) REMOVE r.color");
 
-        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> {
-            assertEquals("color", ((String)row.get("value")));
-        });
-        TestUtil.testCall(db, "CALL apoc.static.get('oldValueProp') YIELD value RETURN value", (row) -> {
-            assertEquals("red", ((String)row.get("value")));
-        });
+        TestUtil.testCall(db, "CALL apoc.static.get('keyProp') YIELD value RETURN value", (row) -> assertEquals("color", row.get("value") ) );
+        TestUtil.testCall(db, "CALL apoc.static.get('oldValueProp') YIELD value RETURN value", (row) -> assertEquals("red", row.get("value") ) );
     }
 
-//    @Test
-    public void testTriggerData_createAndDeleteSameTransaction() throws Exception {
-        db.executeTransactionally("CALL apoc.trigger.add('test','WITH {txData} AS txData RETURN 1',{phase: 'after'}, { uidKey: 'uid', params: {}})");
+    @Test
+    public void testTriggerData_RemovedRelationshipProperties_ByUid_before() {
+        testTriggerData_RemovedRelationshipProperties_ByUid("before");
+    }
+
+    @Test
+    public void testTriggerData_RemovedRelationshipProperties_ByUid_after() {
+        testTriggerData_RemovedRelationshipProperties_ByUid("after");
+    }
+
+    private void testTriggerData_createAndDeleteSameTransaction( String phase ) {
+        db.executeTransactionally("CALL apoc.trigger.add('test','WITH $txData AS txData RETURN 1',{phase: '" + phase + "'}, { params: {uidKeys: ['uid']}})");
 
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})-[r:BAR {uid:'uid-rel-1'}]->(g:Foo {name:'John'})");
         db.executeTransactionally("MATCH (f:Foo {name:'Michael'}) DETACH DELETE f");
     }
 
+    @Test
+    public void testTriggerData_createAndDeleteSameTransaction_before() {
+        testTriggerData_createAndDeleteSameTransaction("before");
+    }
 
-
+    @Test
+    public void testTriggerData_createAndDeleteSameTransaction_after() {
+        testTriggerData_createAndDeleteSameTransaction("after");
+    }
 }


### PR DESCRIPTION
Update the trigger data tests to use the new $param syntax so they can run.
Update the TriggerHandler and TransactionDataMap classes so the TxDataWrapper can be constructed in the after phase.

Fixes #43 

Get the trigger data tests passing again.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - replace `{param}` syntax with `$param` in the tests
  - modify trigger Cypher in the tests so accessing the various parts of the tx data is the same as in the other branches
  - update the `TriggerHandler` and `TranscationDataMap` classes to the `TxDataWrapper` can be constructed in both the `before` and `after` phases.
