### PR TITLE
4.0 - dynamicFix

### DIFF
--- a/src/main/java/apoc/cache/Dynamic.java
+++ b/src/main/java/apoc/cache/Dynamic.java
@@ -32,7 +32,7 @@ public class Dynamic
     public Stream<StringResult> open( @Name( value = "keySize", defaultValue = "5" ) String keySize )
     {
         Integer keySizeInt = Integer.parseInt( keySize );
-        String generatedKey = RandomStringUtils.random( keySizeInt );
+        String generatedKey = RandomStringUtils.randomAlphabetic( keySizeInt );
 
         while ( storage.containsKey( generatedKey ) )
         {


### PR DESCRIPTION
Changes 'apoc.dynamic.open' to use alphabetic letters so the keySize is consistent.