### PR TITLE
apoc.map.unflatten function, fixes #69

### DIFF
--- a/src/main/java/apoc/map/Maps.java
+++ b/src/main/java/apoc/map/Maps.java
@@ -268,6 +268,36 @@ public class Maps {
     }
 
     @UserFunction
+    @Description("apoc.map.unflatten(map) yield map - unflattens dot notated nested items in map")
+    public Map<String,Object> unflatten( @Name( "flatMap" ) Map<String,Object> flatMap ) {
+        Map<String,Object> unflattenedMap = new HashMap<>();
+
+        for ( Map.Entry<String, Object> entry : flatMap.entrySet() ) {
+            String[] keys = entry.getKey().split( "\\." );
+
+            Map<String, Object> current = unflattenedMap;
+
+            for ( int i = 0; i < keys.length - 1; ++i ) {
+                String key = keys[i];
+
+                Object temp = current.get( key );
+                if ( temp == null ) {
+                    Map<String, Object> next = new HashMap<>();
+                    current.put( key, next );
+                    current = next;
+                    continue;
+                }
+
+                current = (Map<String, Object>) temp;
+            }
+
+            current.put( keys[keys.length - 1], entry.getValue() );
+        }
+
+        return unflattenedMap;
+    }
+
+    @UserFunction
     @Description("apoc.map.sortedProperties(map, ignoreCase:true) - returns a list of key/value list pairs, with pairs sorted by keys alphabetically, with optional case sensitivity")
     public List<List<Object>> sortedProperties(@Name("map") Map<String, Object> map, @Name(value="ignoreCase", defaultValue = "true") boolean ignoreCase) {
         List<List<Object>> sortedProperties = new ArrayList<>();

--- a/src/test/java/apoc/map/MapsTest.java
+++ b/src/test/java/apoc/map/MapsTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.util.*;
@@ -231,6 +232,22 @@ public class MapsTest {
                     "nested.nested.somekey", "someValue",
                     "nested.nested.somenumeric", 123), resultMap);
         });
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUnflatten() {
+        Map<String, Object> flatMap = map( "string", "value", "int", 10, "nested.anotherkey", "anotherValue", "nested.nested.somekey", "someValue", "nested.nested.somenumeric", 123 );
+        TestUtil.testCall( db, "RETURN apoc.map.unflatten($map) AS value", map( "map", flatMap ), (r) -> {
+            Map<String, Object> resultMap = (Map<String, Object>)r.get( "value" );
+            assertEquals( map( "string", "value", "int", 10, "nested", map( "anotherkey", "anotherValue", "nested", map( "somekey", "someValue", "somenumeric", 123 ) ) ), resultMap );
+        } );
+    }
+
+    @Test (expected = QueryExecutionException.class)
+    public void testUnflattenConflictingKeys() {
+        Map<String, Object> flatMap = map( "key", "value", "key.nested", "anotherValue" );
+        TestUtil.testCall( db, "RETURN apoc.map.unflatten($map) AS value", map( "map", flatMap ), (r) -> {} );
     }
 
     @Test


### PR DESCRIPTION
Provides the inverse of the apoc.map.flatten function.

Fixes #69

Adds the function `apoc.map.unflatten` to provide the inverse operation of `apoc.map.flatten`.

## Proposed Changes

`apoc.map.unflatten` accepts a `Map<String, Object>` where the keys are separated with dot-notation (e.g. `topLevelKey.nestedKey`).
If two keys try to use conflicting types for a key (e.g. `"foo": "bar"` and `"foo.nested": "baz"`), then the function will throw a `ClassCastException`.