### PR TITLE
apoc.map.unflatten function, fixes #69

### DIFF
--- a/src/main/java/apoc/map/Maps.java
+++ b/src/main/java/apoc/map/Maps.java
@@ -296,6 +296,36 @@ public class Maps {
     }
 
     @UserFunction
+    @Description("apoc.map.unflatten(map) yield map - unflattens dot notated nested items in map")
+    public Map<String,Object> unflatten( @Name( "flatMap" ) Map<String,Object> flatMap ) {
+        Map<String,Object> unflattenedMap = new HashMap<>();
+
+        for ( Map.Entry<String, Object> entry : flatMap.entrySet() ) {
+            String[] keys = entry.getKey().split( "\\." );
+
+            Map<String, Object> current = unflattenedMap;
+
+            for ( int i = 0; i < keys.length - 1; ++i ) {
+                String key = keys[i];
+
+                Object temp = current.get( key );
+                if ( temp == null ) {
+                    Map<String, Object> next = new HashMap<>();
+                    current.put( key, next );
+                    current = next;
+                    continue;
+                }
+
+                current = (Map<String, Object>) temp;
+            }
+
+            current.put( keys[keys.length - 1], entry.getValue() );
+        }
+
+        return unflattenedMap;
+    }
+
+    @UserFunction
     @Description("apoc.map.sortedProperties(map, ignoreCase:true) - returns a list of key/value list pairs, with pairs sorted by keys alphabetically, with optional case sensitivity")
     public List<List<Object>> sortedProperties(@Name("map") Map<String, Object> map, @Name(value="ignoreCase", defaultValue = "true") boolean ignoreCase) {
         List<List<Object>> sortedProperties = new ArrayList<>();


### PR DESCRIPTION
Provides the inverse of the `apoc.map.flatten` function.

Fixes #69

Adds the function `apoc.map.unflatten` to provide the inverse operation of `apoc.map.flatten`.

Proposed Changes
`apoc.map.unflatten` accepts a `Map<String, Object>` where the keys are separated with dot-notation (e.g. `topLevelKey.nestedKey`).
If two keys try to use conflicting types for a key (e.g. `"foo": "bar"` and `"foo.nested": "baz"`), then the function will throw a `ClassCastException`.
