### PR TITLE
3.4 - Broker Tests (RMQ)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,8 @@ dependencies {
     testCompile group: 'org.testcontainers', name: 'couchbase', version: '1.11.0'
     testCompile group: 'org.testcontainers', name: 'mysql', version: '1.11.0'
     testCompile group: 'org.testcontainers', name: 'postgresql', version: '1.11.0'
+    testCompile group: 'org.testcontainers', name: 'rabbitmq', version: '1.12.5'
+
 
     testCompile group: 'com.github.adejanovski', name: 'cassandra-jdbc-wrapper', version: '3.1.0'
     testCompile group: 'com.codahale.metrics', name: 'metrics-core', version: '3.0.2'

--- a/src/test/java/apoc/broker/BrokerRabbitMQTests.java
+++ b/src/test/java/apoc/broker/BrokerRabbitMQTests.java
@@ -1,0 +1,406 @@
+package apoc.broker;
+
+import apoc.container.RabbitMQContainerExtension;
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestUtil;
+import com.google.common.collect.ImmutableMap;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.Transaction;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.rnorth.ducttape.unreliables.Unreliables;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.Network;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static apoc.container.RabbitMQContainerExtension.DEFAULT_AMQP_PORT;
+import static apoc.util.TestContainerUtil.cleanBuild;
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestContainerUtil.executeGradleTasks;
+import static apoc.util.TestUtil.isTravis;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNotNull;
+
+public class BrokerRabbitMQTests
+{
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
+
+    private static RabbitMQContainerExtension rabbitMQContainerExtension;
+    private static ConnectionFactory connectionFactory;
+    private static Connection connection;
+    private static Channel channel;
+
+    private static String RABBITMQ = "rabbitmq";
+
+    private static String QUEUE_NAME = "test.queue";
+    private static String EXCHANGE_NAME = "test.exchange";
+    private static String KEY_NAME = "test.key";
+
+    private static Map<String,Object> TEST_MESSAGE = ImmutableMap.of( "test", 1 );
+    private static String uniquePostfix = RandomStringUtils.randomAlphabetic( 4 );
+
+    private static String SEND = "CALL apoc.broker.send( $connectionName, $message, $config )";
+    private static String RECEIVE = "CALL apoc.broker.receive( $connectionName, $config )";
+
+    @BeforeClass
+    public static void beforeClass() throws Exception
+    {
+        assumeFalse( isTravis() );
+
+        // Set up test containers network so Neo4j can communicate with RabbitMQ
+        Network network = Network.newNetwork();
+
+        // Set up RabbitMQ test container
+        TestUtil.ignoreException( () -> {
+            rabbitMQContainerExtension = new RabbitMQContainerExtension()
+                    .withLogging()
+                    .durableExchange( EXCHANGE_NAME )
+                    .durableQueue( QUEUE_NAME )
+                    .queueBinding( EXCHANGE_NAME, QUEUE_NAME, KEY_NAME )
+                    .withNetwork( network )
+                    .withNetworkAliases( RABBITMQ );
+            rabbitMQContainerExtension.start();
+        }, Exception.class);
+        assumeNotNull(rabbitMQContainerExtension);
+
+
+
+        TestUtil.ignoreException(() -> {
+            executeGradleTasks("clean", "shadow");
+            neo4jContainer = createEnterpriseDB(true)
+                    .withoutAuthentication()
+                    .withNeo4jConfig( "apoc.broker.rabbitmq.type", "RABBITMQ" )
+                    .withNeo4jConfig( "apoc.broker.rabbitmq.enabled", "true" )
+                    .withNeo4jConfig( "apoc.broker.rabbitmq.host", RABBITMQ )
+                    .withNeo4jConfig( "apoc.broker.rabbitmq.port", Integer.toString(  5672 ) )
+                    .withNeo4jConfig( "apoc.broker.rabbitmq.vhost", "/" )
+                    .withNeo4jConfig( "apoc.broker.rabbitmq.username", "guest" )
+                    .withNeo4jConfig( "apoc.broker.rabbitmq.password", "guest" )
+                    .withNeo4jConfig( "apoc.brokers.logs.enabled", "true" )
+                    .withNeo4jConfig( "apoc.brokers.logs.dirPath", "/var/lib/neo4j/logs/" )
+                    .withNetwork( network )
+                    .withNetworkAliases( "neo4j" );
+            neo4jContainer.start();
+        }, Exception.class );
+        assumeNotNull( neo4jContainer );
+
+        session = neo4jContainer.getSession();
+
+        // Set up ConnectionFactory, Connection, and Channel for Asserting during tests.
+        setupRabbitMQObjects();
+    }
+
+    private static void setupRabbitMQObjects() throws IOException, TimeoutException
+    {
+        connectionFactory = new ConnectionFactory();
+        connectionFactory.setHost( rabbitMQContainerExtension.getContainerIpAddress() );
+        connectionFactory.setPort( rabbitMQContainerExtension.getMappedPort( DEFAULT_AMQP_PORT ) );
+        connection = connectionFactory.newConnection();
+        channel = connection.createChannel();
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        if ( neo4jContainer != null )
+        {
+            neo4jContainer.close();
+        }
+
+        if ( rabbitMQContainerExtension != null )
+        {
+            rabbitMQContainerExtension.stop();
+        }
+
+        cleanBuild();
+    }
+
+    @Before
+    public void setUp() throws Exception
+    {
+        uniquePostfix = RandomStringUtils.randomAlphabetic( 4 );
+
+        if ( !rabbitMQContainerExtension.isRunning() )
+        {
+            rabbitMQContainerExtension.start();
+            setupRabbitMQObjects();
+        }
+        else
+        {
+            // If the connection was severed then create a new connection.
+            if ( !connection.isOpen() )
+            {
+                connection = connectionFactory.newConnection();
+            }
+            // Always set up a new channel per test
+            else
+            {
+                channel = connection.createChannel();
+            }
+        }
+    }
+
+    @Test
+    public void test_broker_rabbit_assertSendCreatesExchange()
+    {
+        Assert.assertNotNull( channel );
+
+        final String exchangeName = applyPostfix( EXCHANGE_NAME );
+        final String queueName = QUEUE_NAME;
+        final String routingKey = applyPostfix( KEY_NAME );
+        final Map<String,Object> config = ImmutableMap.of( "exchangeName", exchangeName, "queueName", queueName, "routingKey", routingKey );
+
+        // Ensure the exchange does not already exist
+        try
+        {
+            channel.exchangeDeclarePassive( exchangeName );
+            Assert.fail("Exchange was already created before executing apoc.broker.send");
+        }
+        catch ( IOException ignored )
+        {
+            // Expected IOException. RabbitMQ channel will be closed from the error, need to create a new one.
+            try
+            {
+                channel = connection.createChannel();
+            }
+            catch ( IOException e )
+            {
+                Assert.fail("Unexpected IOException while recreating channel.");
+            }
+        }
+
+        // Run apoc.broker.send to create the exchange
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            tx.run( SEND, ImmutableMap.of( "connectionName", RABBITMQ, "config", config, "message", TEST_MESSAGE ) );
+        }
+
+
+        // Verify the exchange was created.
+        try
+        {
+            channel.exchangeDeclarePassive( exchangeName );
+        }
+        catch ( IOException e )
+        {
+            Assert.fail( "RabbitMQ exchange '" + exchangeName + "' was not created by apoc.broker.send" );
+        }
+    }
+
+
+    @Test
+    public void test_broker_rabbit_assertSendCreatesQueue()
+    {
+        Assert.assertNotNull( channel );
+
+        final String exchangeName = EXCHANGE_NAME;
+        final String queueName = applyPostfix( QUEUE_NAME );
+        final String routingKey = KEY_NAME;
+        final Map<String,Object> config = ImmutableMap.of( "exchangeName", exchangeName, "queueName", queueName, "routingKey", routingKey );
+
+        // Ensure the queue does not already exist
+        try
+        {
+            channel.queueDeclarePassive( queueName );
+            Assert.fail("Queue was already created before executing apoc.broker.send");
+        }
+        catch ( IOException ignored )
+        {
+            // Expected IOException. RabbitMQ channel will be closed from the error, need to create a new one.
+            try
+            {
+                channel = connection.createChannel();
+            }
+            catch ( IOException e )
+            {
+                Assert.fail("Unexpected IOException while recreating channel.");
+            }
+        }
+
+        // Run apoc.broker.send to create the queue
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            tx.run( SEND, ImmutableMap.of( "connectionName", RABBITMQ, "config", config, "message", TEST_MESSAGE ) );
+        }
+
+
+        // Verify the queue was created.
+        try
+        {
+            channel.queueDeclarePassive( queueName );
+        }
+        catch ( IOException e )
+        {
+            Assert.fail( "RabbitMQ queue '" + queueName + "' was not created by apoc.broker.send" );
+        }
+    }
+
+    @Test
+    public void test_broker_rabbit_assertSend() throws IOException
+    {
+        Assert.assertNotNull( channel );
+
+        final String exchangeName = EXCHANGE_NAME;
+        final String queueName = QUEUE_NAME;
+        final String routingKey = KEY_NAME;
+        final Map<String,Object> config = ImmutableMap.of( "exchangeName", exchangeName, "queueName", queueName, "routingKey", routingKey );
+
+        // Set up temporary consumer
+        final boolean[] messageWasReceived = new boolean[1];
+        channel.basicConsume( queueName, new DefaultConsumer( channel )
+        {
+            @Override
+            public void handleDelivery( String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body ) throws IOException
+            {
+                messageWasReceived[0] = Arrays.equals( body, "{\"test\":1}".getBytes() );
+            }
+        } );
+
+        // Run apoc.broker.send and publish a test message
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            tx.run( SEND, ImmutableMap.of( "connectionName", RABBITMQ, "config", config, "message", TEST_MESSAGE ) );
+        }
+
+        // check the message was received
+        Assert.assertTrue( "The message was received", Unreliables.retryUntilSuccess( 5, TimeUnit.SECONDS, () -> {
+            if ( !messageWasReceived[0] )
+            {
+                throw new IllegalStateException( "Message not received yet" );
+            }
+            return true;
+        } ) );
+    }
+
+
+    @Test
+    public void test_broker_rabbit_assertReconnectAndResend() throws IOException, TimeoutException, InterruptedException
+    {
+        Assert.assertNotNull( channel );
+        final String exchangeName = applyPostfix( EXCHANGE_NAME );
+        final String queueName = applyPostfix( QUEUE_NAME );
+        final String routingKey = applyPostfix( KEY_NAME );
+        final Map<String,Object> config = ImmutableMap.of( "exchangeName", exchangeName, "queueName", queueName, "routingKey", routingKey );
+
+        boolean runtimeException = false;
+
+        // Stop RabbitMQContainer to simulate a crash
+        rabbitMQContainerExtension.stop();
+
+        // Run apoc.broker.send
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            tx.run( SEND, ImmutableMap.of( "connectionName", RABBITMQ, "config", config, "message", TEST_MESSAGE ) );
+        }
+        catch ( ClientException ignored )
+        {
+            // Expected ClientException
+            runtimeException = true;
+        }
+
+        if ( !runtimeException )
+        {
+            Assert.fail( "Expected a thrown ClientException when sending a RMQ message to a closed channel." );
+        }
+
+        // Start the rabbitMQContainerExtension up again.
+        rabbitMQContainerExtension.start();
+        setupRabbitMQObjects();
+
+        // Wait the max amount of time (+ 100ms) for Neo4j to reconnect, then check that messages have been sent.
+        waitForBrokerToReconnect();
+
+
+        // Set up temporary consumer
+        final boolean[] messageWasReceived = new boolean[1];
+        channel.basicConsume( queueName, new DefaultConsumer( channel )
+        {
+            @Override
+            public void handleDelivery( String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body ) throws IOException
+            {
+                messageWasReceived[0] = Arrays.equals( body, "{\"test\":1}".getBytes() );
+            }
+        } );
+
+        // check the message was sent by consuming it
+        Assert.assertTrue( "The message was received", Unreliables.retryUntilSuccess( 5, TimeUnit.SECONDS, () -> {
+            if ( !messageWasReceived[0] )
+            {
+                throw new IllegalStateException( "Message not received yet" );
+            }
+            return true;
+        } ) );
+    }
+
+    @Test
+    public void test_broker_rabbit_assertBrokerLogging() throws IOException, TimeoutException, InterruptedException
+    {
+        Assert.assertNotNull( channel );
+        final String exchangeName = applyPostfix( EXCHANGE_NAME );
+        final String queueName = applyPostfix( QUEUE_NAME );
+        final String routingKey = applyPostfix( KEY_NAME );
+        final Map<String,Object> config = ImmutableMap.of( "exchangeName", exchangeName, "queueName", queueName, "routingKey", routingKey );
+
+        boolean runtimeException = false;
+
+        // Ensure that rabbitmq.log in ONgDB Container is empty
+        Container.ExecResult catResult = neo4jContainer.execInContainer( "cat", "/var/lib/neo4j/logs/rabbitmq.log" );
+        Assert.assertTrue( catResult.getStdout().isEmpty() );
+
+        // Stop RabbitMQContainer to simulate a crash
+        rabbitMQContainerExtension.stop();
+
+        // Run apoc.broker.send
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            tx.run( SEND, ImmutableMap.of( "connectionName", RABBITMQ, "config", config, "message", TEST_MESSAGE ) );
+        }
+        catch ( ClientException ignored )
+        {
+            // Expected ClientException
+            runtimeException = true;
+        }
+
+        if ( !runtimeException )
+        {
+            Assert.fail( "Expected a thrown ClientException when sending a RMQ message to a closed channel." );
+        }
+
+        // Assert that the rabbitmq.log is non-empty
+        catResult = neo4jContainer.execInContainer( "cat", "/var/lib/neo4j/logs/rabbitmq.log" );
+        Assert.assertFalse( catResult.getStdout().isEmpty() );
+
+        // Start the rabbitMQContainerExtension up again.
+        rabbitMQContainerExtension.start();
+        setupRabbitMQObjects();
+        // Sleep to ensure that Neo4j has reconnected.
+        waitForBrokerToReconnect();
+    }
+
+    private static String applyPostfix( String s )
+    {
+        return s + "_" + uniquePostfix;
+    }
+
+    private static void waitForBrokerToReconnect() throws InterruptedException
+    {
+        Thread.sleep( 17 * 1000 + 100 );
+    }
+}

--- a/src/test/java/apoc/container/RabbitMQContainerExtension.java
+++ b/src/test/java/apoc/container/RabbitMQContainerExtension.java
@@ -1,0 +1,69 @@
+package apoc.container;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class RabbitMQContainerExtension extends RabbitMQContainer
+{
+    private static final Logger logger = LoggerFactory.getLogger( RabbitMQContainerExtension.class );
+
+    public static final int DEFAULT_AMQP_PORT = 5672;
+
+    @Override
+    public void start()
+    {
+        super.start();
+    }
+
+    public RabbitMQContainerExtension withLogging()
+    {
+        withLogConsumer( new Slf4jLogConsumer( logger ) );
+        return this;
+    }
+
+    public RabbitMQContainerExtension durableQueue( String name )
+    {
+        return durableQueue( name, Collections.emptyMap() );
+    }
+
+    public RabbitMQContainerExtension durableQueue( String name, Map<String,Object> args )
+    {
+        this.withQueue( name, false, true, args );
+        return this;
+    }
+
+    public RabbitMQContainerExtension durableExchange( String name )
+    {
+        return durableExchange( name, Collections.emptyMap() );
+    }
+
+    public RabbitMQContainerExtension durableExchange( String name, Map<String,Object> args )
+    {
+        this.withExchange( name, "direct", false, false, true, args );
+        return this;
+    }
+
+    public RabbitMQContainerExtension queueBinding( String src, String dst, String key )
+    {
+        this.withBinding( src, dst, Collections.emptyMap(), key, "queue" );
+        return this;
+    }
+
+    @Override
+    public RabbitMQContainerExtension withNetwork( Network network )
+    {
+        return (RabbitMQContainerExtension) super.withNetwork( network );
+    }
+
+    @Override
+    public RabbitMQContainerExtension withNetworkAliases( String... aliases )
+    {
+        return (RabbitMQContainerExtension) super.withNetworkAliases( aliases );
+    }
+}

--- a/src/test/java/apoc/util/TestContainerUtil.java
+++ b/src/test/java/apoc/util/TestContainerUtil.java
@@ -33,12 +33,17 @@ public class TestContainerUtil {
 
     public static Neo4jContainerExtension createEnterpriseDB(boolean withLogging) {
         // We define the container with external volumes
-        Neo4jContainerExtension neo4jContainer = new Neo4jContainerExtension("neo4j:3.4.12-enterprise")
+        Neo4jContainerExtension neo4jContainer = new Neo4jContainerExtension("graphfoundation/ongdb:3.4.15")
                 .withPlugins(MountableFile.forHostPath("./target/tests/gradle-build/libs")) // map the apoc's artifact dir as the Neo4j's plugin dir
                 .withAdminPassword("apoc")
                 .withNeo4jConfig("apoc.export.file.enabled", "true")
                 .withNeo4jConfig("dbms.security.procedures.unrestricted", "apoc.*")
 //                .withEnv("NEO4J_wrapper_java_additional","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -Xdebug-Xnoagent-Djava.compiler=NONE-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005")
+                // Allows debugging apoc running on a neo4j container.
+                // To connect with the remote debugger don't use port 5005, instead use the mapped port. <port> in `0.0.0.0:<port>->5005/tcp` found by `docker ps`
+                .withEnv("NEO4J_dbms_jvm_additional","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005")
+                .withExposedPorts( 5005 )
+
                 .withFileSystemBind("./target/import", "/import") // map the "target/import" dir as the Neo4j's import dir
                 .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes");
         if (withLogging) {


### PR DESCRIPTION
Fixes #68 by adding in Broker Tests for RabbitMQ apoc integration.

Adds the tests for sending, reconnecting, logging, and creating queue/channel.