### PR TITLE
3.4 - Broker Initialization Logging

### DIFF
--- a/src/main/java/apoc/broker/BrokerExceptionHandler.java
+++ b/src/main/java/apoc/broker/BrokerExceptionHandler.java
@@ -9,6 +9,9 @@ import apoc.broker.exception.BrokerReceiveException;
 import apoc.broker.exception.BrokerResendDisabledException;
 import apoc.broker.exception.BrokerRuntimeException;
 import apoc.broker.exception.BrokerSendException;
+
+import java.net.ConnectException;
+
 import org.neo4j.logging.Log;
 
 /**
@@ -189,14 +192,19 @@ public class BrokerExceptionHandler
     public static BrokerConnectionInitializationException brokerConnectionInitializationException( String msg, Throwable e )
     {
         BrokerConnectionInitializationException brokerException;
-        if ( e != null )
+        if ( e == null )
         {
-            brokerException = new BrokerConnectionInitializationException( msg, e );
-            log.error( brokerException.getMessage(), e );
+            brokerException = new BrokerConnectionInitializationException( msg );
+            log.error( brokerException.getMessage() );
+        }
+        else if ( e instanceof ConnectException )
+        {
+            brokerException = new BrokerConnectionInitializationException( msg + " " + e );
+            log.warn( brokerException.getMessage() );
         }
         else
         {
-            brokerException = new BrokerConnectionInitializationException( msg );
+            brokerException = new BrokerConnectionInitializationException( msg, e );
             log.error( brokerException.getMessage() );
         }
 

--- a/src/main/java/apoc/broker/KafkaConnectionFactory.java
+++ b/src/main/java/apoc/broker/KafkaConnectionFactory.java
@@ -90,6 +90,7 @@ public class KafkaConnectionFactory implements ConnectionFactory
                 if ( verboseErrorLogging )
                 {
                     BrokerExceptionHandler.brokerConnectionInitializationException( "Failed to initialize Kafka connection '" + connectionName + "'.", e );
+                    log.warn( "APOC Broker: Initializing Kafka connection '" + connectionName + "' will be retried." );
                 }
                 connected.set( false );
             }

--- a/src/main/java/apoc/broker/RabbitMqConnectionFactory.java
+++ b/src/main/java/apoc/broker/RabbitMqConnectionFactory.java
@@ -96,6 +96,7 @@ public class RabbitMqConnectionFactory implements apoc.broker.ConnectionFactory
                 if ( verboseErrorLogging )
                 {
                     BrokerExceptionHandler.brokerConnectionInitializationException( "Failed to initialize RabbitMQ connection '" + connectionName + "'.", e );
+                    log.warn( "APOC Broker: Initializing RabbitMQ connection '" + connectionName + "' will be retried." );
                 }
                 connected.set( false );
             }

--- a/src/main/java/apoc/broker/SqsConnectionFactory.java
+++ b/src/main/java/apoc/broker/SqsConnectionFactory.java
@@ -71,6 +71,7 @@ public class SqsConnectionFactory implements ConnectionFactory
                 if ( verboseErrorLogging )
                 {
                     BrokerExceptionHandler.brokerConnectionInitializationException( "Failed to initialize SQS connection '" + connectionName + "'.", e );
+                    log.warn( "APOC Broker: Initializing SQS connection '" + connectionName + "' will be retried." );
                 }
                 connected.set( false );
             }


### PR DESCRIPTION
Clean up log output on a `ConnectionException` when initializing a broker connection.

Remove stack trace from log.
Add message that initializing the connection will be retried.

When spinning up ONgDB and RabbitMQ together through Docker, ONgDB can get to broker connection initialization before RMQ is ready.
This puts a number of `ERROR` messages in the ONgDB log as it tries to establish the connection.

Sample error message:
```
ERROR [BrokerConnectionInitializationException] Failed to initialize RabbitMQ connection 'rabbitmq'. Connection refused (Connection refused)
java.net.ConnectException: Connection refused (Connection refused)
    at java.net.PlainSocketImpl.socketConnect(Native Method)
```

## Proposed Changes

- during broker initialization, use a `WARN` log message when unable to establish the connection
- remove stack traces from broker connection error log output

Sample of the new broker log messages (not just the errors):
```
INFO  APOC Broker: Adding RabbitMQ Connection 'rabbitmq' with configurations {vhost=/, password=guest, port=5672, host=rabbitmq, type=RABBITMQ, enabled=true, username=guest}
WARN  [BrokerConnectionInitializationException] Failed to initialize RabbitMQ connection 'rabbitmq'. java.net.ConnectException: Connection refused (Connection refused)
WARN  APOC Broker: Initializing RabbitMQ connection 'rabbitmq' will be retried.
ERROR [BrokerRuntimeException] RabbitMQ connection 'rabbitmq' failed healthcheck.
ERROR [BrokerRuntimeException] RabbitMQ connection 'rabbitmq' failed healthcheck.
INFO  APOC Broker: Connection 'rabbitmq' reconnected.
```